### PR TITLE
Enhance array API compatibility and improve type hints

### DIFF
--- a/examples/tutorial.py
+++ b/examples/tutorial.py
@@ -314,7 +314,7 @@ def _(np, rng, translate):
     translated_town = town_adapter.apply(translate, my_town)
 
     town_translator = town_adapter.partial(translate)
-    translated_town_2 = town_translator(translated_town)
+    translated_town_2 = town_translator(translated_town)  # noqa: F841
     return
 
 

--- a/justfile
+++ b/justfile
@@ -14,13 +14,13 @@ doc:
 
 # Run linters and type checkers.
 lint:
-    uv run ruff check src tests
-    uv run mypy src tests
-    uv run ruff format --check src tests
+    uv run ruff check src tests examples
+    uv run mypy src tests examples
+    uv run ruff format --check src tests examples
 
 # Format python code.
 format:
-    uv run ruff format src tests
+    uv run ruff format src tests examples
 
 # Run unit tests.
 test:

--- a/justfile
+++ b/justfile
@@ -15,7 +15,7 @@ doc:
 # Run linters and type checkers.
 lint:
     uv run ruff check src tests examples
-    uv run mypy src tests examples
+    uv run mypy src tests
     uv run ruff format --check src tests examples
 
 # Format python code.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,8 @@ authors = [
 requires-python = ">=3.12, <4.0"
 dependencies = [
     "numpy>=2",
-    "networkx>=3"
+    "networkx>=3",
+    "array_api_compat>=1.14",
 ]
 license = "MIT"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,31 +3,16 @@ name = "transformnd"
 version = "0.1.0"
 description = "ND coordinate transformations"
 readme = "README.md"
-authors = [
-    { name = "Chris Barnes", email = "chris.barnes@gerbi-gmb.de" }
-]
+authors = [{ name = "Chris Barnes", email = "chris.barnes@gerbi-gmb.de" }]
 requires-python = ">=3.12, <4.0"
-dependencies = [
-    "numpy>=2",
-    "networkx>=3",
-    "array_api_compat>=1.14",
-]
+dependencies = ["numpy>=2", "networkx>=3", "array_api_compat>=1.14"]
 license = "MIT"
 
 [project.optional-dependencies]
-thinplatesplines = [
-    "morphops>=0.1.13",
-    "scipy>=1.17.1",
-]
-movingleastsquares = [
-    "molesq>=0.4.0",
-]
-pandas = [
-    "pandas>=3.0.2",
-]
-shapely = [
-    "shapely>=2.1.2",
-]
+thinplatesplines = ["morphops>=0.1.13", "scipy>=1.17.1"]
+movingleastsquares = ["molesq>=0.4.0"]
+pandas = ["pandas>=3.0.2"]
+shapely = ["shapely>=2.1.2"]
 
 [dependency-groups]
 dev = [
@@ -36,7 +21,7 @@ dev = [
     {include-group = "doc"},
     {include-group = "tutorial"},
 ]
-test = ["pytest"]
+test = ["pytest", "jax"]
 lint = [
     "ruff",
     "mypy",

--- a/src/transformnd/adapters/base.py
+++ b/src/transformnd/adapters/base.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from copy import deepcopy
 from functools import partial
 from collections.abc import Callable
-from typing import Generic, TypeVar
+from typing import TypeVar
 
 import numpy as np
 
@@ -13,7 +13,7 @@ from ..base import Transform
 T = TypeVar("T")
 
 
-class BaseAdapter(Generic[T], ABC):
+class BaseAdapter[T](ABC):
     @abstractmethod
     def apply(self, transform: Transform, obj: T) -> T:
         """Apply the given transformation to a non-array object.

--- a/src/transformnd/adapters/base.py
+++ b/src/transformnd/adapters/base.py
@@ -152,12 +152,12 @@ class ReshapeAdapter(BaseAdapter[np.ndarray]):
         """
         self.dim_axis: int = dim_axis
 
-    def apply(self, transform: Transform, arr: np.ndarray) -> np.ndarray:
+    def apply(self, transform: Transform, obj: np.ndarray) -> np.ndarray:
         dim_axis = self.dim_axis
         if self.dim_axis < 0:
-            dim_axis += arr.ndim
+            dim_axis += obj.ndim
 
-        moved = np.moveaxis(arr, dim_axis, -1)
+        moved = np.moveaxis(obj, dim_axis, -1)
         m_shape = moved.shape
 
         flattened = np.reshape(moved, (-1, m_shape[-1]))

--- a/src/transformnd/adapters/base.py
+++ b/src/transformnd/adapters/base.py
@@ -3,7 +3,8 @@
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from functools import partial
-from typing import Callable, Generic, Optional, TypeVar
+from collections.abc import Callable
+from typing import Generic, TypeVar
 
 import numpy as np
 
@@ -70,7 +71,7 @@ NULL = NullAdapter()
 
 
 class AttrAdapter(BaseAdapter[T]):
-    def __init__(self, **kwargs: Optional[BaseAdapter]) -> None:
+    def __init__(self, **kwargs: BaseAdapter | None) -> None:
         """Adapter which transforms an object by applying transforms to its attributes.
 
         Parameters

--- a/src/transformnd/adapters/base.py
+++ b/src/transformnd/adapters/base.py
@@ -29,7 +29,7 @@ class BaseAdapter(Generic[T], ABC):
         """
         pass
 
-    def partial(self, *args, **kwargs) -> Callable:
+    def partial(self, *args, **kwargs) -> Callable[..., T]:
         """Create a partial function with frozen arguments.
 
         Useful for applying the same transform to many objects,
@@ -85,7 +85,7 @@ class AttrAdapter(BaseAdapter[T]):
         """
         self.adapters = {k: NULL if v is None else v for k, v in kwargs.items()}
 
-    def apply(self, transform: Transform, obj: T, in_place=False) -> T:
+    def apply(self, transform: Transform, obj: T, in_place: bool = False) -> T:
         """Apply the given transformation to the object, via its attributes.
 
         Parameters
@@ -117,7 +117,7 @@ class AttrAdapter(BaseAdapter[T]):
         return obj
 
 
-class SimpleAdapter(BaseAdapter, Generic[T], ABC):
+class SimpleAdapter(BaseAdapter[T], ABC):
     """
     Helper class for cases with simple conversion methods.
     """
@@ -141,7 +141,7 @@ class SimpleAdapter(BaseAdapter, Generic[T], ABC):
 class ReshapeAdapter(BaseAdapter[np.ndarray]):
     """Adapter which reshapes a numpy.ndarray"""
 
-    def __init__(self, dim_axis=-1) -> None:
+    def __init__(self, dim_axis: int = -1) -> None:
         """Adapt numpy arrays which are not of the correct shape.
 
         Parameters

--- a/src/transformnd/adapters/pandas.py
+++ b/src/transformnd/adapters/pandas.py
@@ -20,7 +20,7 @@ class DataFrameAdapter(BaseAdapter[pd.DataFrame]):
         self.columns = columns
 
     def apply(
-        self, transform: Transform, df: pd.DataFrame, in_place=False
+        self, transform: Transform, df: pd.DataFrame, in_place: bool = False
     ) -> pd.DataFrame:
         """Transform the dataframe, optionally in-place.
 

--- a/src/transformnd/adapters/pandas.py
+++ b/src/transformnd/adapters/pandas.py
@@ -1,6 +1,6 @@
 """Adapt pandas DataFrames for transformation."""
 
-from typing import Hashable, List
+from collections.abc import Hashable
 
 import pandas as pd
 
@@ -9,7 +9,7 @@ from .base import BaseAdapter
 
 
 class DataFrameAdapter(BaseAdapter[pd.DataFrame]):
-    def __init__(self, columns: List[Hashable]):
+    def __init__(self, columns: list[Hashable]):
         """Adapt transformation for coordinates stored in a pandas DataFrame.
 
         Parameters

--- a/src/transformnd/adapters/shapely.py
+++ b/src/transformnd/adapters/shapely.py
@@ -43,7 +43,9 @@ class GeometryAdapter(BaseAdapter[BaseGeometry]):
             [self.transform_linear_ring(transform, i) for i in polygon.interiors],
         )
 
-    def transform_multi(self, transform: Transform, multi_geom: BaseMultipartGeometry) -> BaseMultipartGeometry:
+    def transform_multi(
+        self, transform: Transform, multi_geom: BaseMultipartGeometry
+    ) -> BaseMultipartGeometry:
         cls = type(multi_geom)
         method = {
             MultiPoint: self.transform_point,

--- a/src/transformnd/adapters/shapely.py
+++ b/src/transformnd/adapters/shapely.py
@@ -43,7 +43,7 @@ class GeometryAdapter(BaseAdapter[BaseGeometry]):
             [self.transform_linear_ring(transform, i) for i in polygon.interiors],
         )
 
-    def transform_multi(self, transform: Transform, multi_geom):
+    def transform_multi(self, transform: Transform, multi_geom: BaseMultipartGeometry) -> BaseMultipartGeometry:
         cls = type(multi_geom)
         method = {
             MultiPoint: self.transform_point,

--- a/src/transformnd/base.py
+++ b/src/transformnd/base.py
@@ -20,7 +20,6 @@ from .util import (
     window,
     SpaceTuple,
     ArrayT,
-    Namespace
 )
 
 

--- a/src/transformnd/base.py
+++ b/src/transformnd/base.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Iterator, Sequence
 from copy import copy
-from typing import Iterator, List, Optional, Sequence, Set, Union, Generic
+from typing import Generic, Self
 
 import numpy as np
 from array_api_compat import array_namespace
@@ -26,7 +27,7 @@ from .util import (
 class Transform(ABC, Generic[ArrayT]):
     """Base class for transforms."""
 
-    ndim: Optional[Set[int]] = None
+    ndim: set[int] | None = None
 
     def __init__(
         self,
@@ -97,7 +98,7 @@ class Transform(ABC, Generic[ArrayT]):
         """
         return NotImplemented
 
-    def to_device(self, xp, device=None) -> "Transform":  # noqa: ARG002
+    def to_device(self, xp, device=None) -> Self:  # noqa: ARG002
         """Return a copy of this transform with array parameters placed on the given device.
 
         Useful for pre-allocating parameters on GPU before a tight apply() loop,
@@ -174,7 +175,7 @@ class TransformWrapper(Transform):
     def __init__(
         self,
         fn: TransformSignature,
-        ndim: Optional[Union[Set[int], int]] = None,
+        ndim: set[int] | int | None = None,
         *,
         spaces: SpaceTuple = (None, None),
     ):
@@ -203,7 +204,11 @@ class TransformWrapper(Transform):
         return self.fn(coords)
 
 
-def _with_spaces(t: Transform, source_space=None, target_space=None):
+def _with_spaces(
+    t: Transform,
+    source_space: SpaceRef | None = None,
+    target_space: SpaceRef | None = None,
+) -> Transform:
     src_tgt = (t.source_space, t.target_space)
     src = same_or_none(src_tgt[0], source_space, default=None)
     tgt = same_or_none(src_tgt[1], target_space, default=None)
@@ -215,7 +220,7 @@ def _with_spaces(t: Transform, source_space=None, target_space=None):
 
 def infer_spaces(
     transforms: Sequence[Transform], source_space=None, target_space=None
-) -> List[Transform]:
+) -> list[Transform]:
     prev_tgts = [source_space]
     next_srcs = []
     for t1, t2 in window(transforms, 2):
@@ -230,7 +235,7 @@ def infer_spaces(
     return out
 
 
-def get_transform_list(t: Transform) -> List[Transform]:
+def get_transform_list(t: Transform) -> list[Transform]:
     if isinstance(t, TransformSequence):
         return t.transforms.copy()
     else:
@@ -274,7 +279,7 @@ class TransformSequence(Transform[ArrayT], Sequence[Transform[ArrayT]]):
             ),
         )
 
-        self.transforms: List[Transform] = ts
+        self.transforms: list[Transform] = ts
 
         self.ndim = None
         for t in self.transforms:
@@ -316,7 +321,7 @@ class TransformSequence(Transform[ArrayT], Sequence[Transform[ArrayT]]):
             coords = t.apply(coords)
         return coords
 
-    def list_spaces(self, skip_none=False) -> List[SpaceRef]:
+    def list_spaces(self, skip_none=False) -> list[SpaceRef]:
         """List spaces in this transform.
 
         Parameters
@@ -338,7 +343,7 @@ class TransformSequence(Transform[ArrayT], Sequence[Transform[ArrayT]]):
         spaces_str = "->".join(space_str(s) for s in self.list_spaces())
         return f"{cls_name}[{spaces_str}]"
 
-    def __getitem__(self, idx: Union[slice, int]):
+    def __getitem__(self, idx: slice | int):
         if isinstance(idx, int):
             return self.transforms[idx]
         return type(self)(self.transforms[idx])

--- a/src/transformnd/base.py
+++ b/src/transformnd/base.py
@@ -97,6 +97,28 @@ class Transform(ABC, Generic[ArrayT]):
         """
         return NotImplemented
 
+    def to_device(self, xp, device=None) -> "Transform":  # noqa: ARG002
+        """Return a copy of this transform with array parameters placed on the given device.
+
+        Useful for pre-allocating parameters on GPU before a tight apply() loop,
+        avoiding per-call host-to-device transfers.
+
+        Parameters
+        ----------
+        xp : array namespace
+            The target array namespace (e.g. jax.numpy, torch).
+        device : device object, optional
+            Target device (e.g. from array_api_compat.device(array)).
+            If None, uses xp's default device.
+
+        Returns
+        -------
+        Transform
+            A new transform instance with parameters on the target device,
+            or NotImplemented if the subclass does not support device placement.
+        """
+        return NotImplemented
+
     def __or__(self, other) -> TransformSequence:
         """Compose transformations into a sequence.
 

--- a/src/transformnd/base.py
+++ b/src/transformnd/base.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Iterator, Sequence
 from copy import copy
-from typing import Generic, Self
+from typing import Self
 
-import numpy as np
 from array_api_compat import array_namespace
 
 from .util import (
@@ -23,7 +22,7 @@ from .util import (
 )
 
 
-class Transform(ABC, Generic[ArrayT]):
+class Transform[ArrayT](ABC):
     """Base class for transforms."""
 
     ndim: set[int] | None = None
@@ -168,12 +167,12 @@ class Transform(ABC, Generic[ArrayT]):
         return f"{cls_name}[{src}->{tgt}]"
 
 
-class TransformWrapper(Transform):
+class TransformWrapper(Transform[ArrayT]):
     """Wrapper around an arbitrary function which transforms coordinates."""
 
     def __init__(
         self,
-        fn: TransformSignature,
+        fn: TransformSignature[ArrayT],
         ndim: set[int] | int | None = None,
         *,
         spaces: SpaceTuple = (None, None),
@@ -198,16 +197,16 @@ class TransformWrapper(Transform):
             else:
                 self.ndim = set(ndim)
 
-    def apply(self, coords: np.ndarray) -> np.ndarray:
+    def apply(self, coords: ArrayT) -> ArrayT:
         self._validate_coords(coords)
         return self.fn(coords)
 
 
 def _with_spaces(
-    t: Transform,
+    t: Transform[ArrayT],
     source_space: SpaceRef | None = None,
     target_space: SpaceRef | None = None,
-) -> Transform:
+) -> Transform[ArrayT]:
     src_tgt = (t.source_space, t.target_space)
     src = same_or_none(src_tgt[0], source_space, default=None)
     tgt = same_or_none(src_tgt[1], target_space, default=None)
@@ -218,8 +217,8 @@ def _with_spaces(
 
 
 def infer_spaces(
-    transforms: Sequence[Transform], source_space=None, target_space=None
-) -> list[Transform]:
+    transforms: Sequence[Transform[ArrayT]], source_space=None, target_space=None
+) -> list[Transform[ArrayT]]:
     prev_tgts = [source_space]
     next_srcs = []
     for t1, t2 in window(transforms, 2):
@@ -234,7 +233,7 @@ def infer_spaces(
     return out
 
 
-def get_transform_list(t: Transform) -> list[Transform]:
+def get_transform_list(t: Transform[ArrayT]) -> list[Transform[ArrayT]]:
     if isinstance(t, TransformSequence):
         return t.transforms.copy()
     else:

--- a/src/transformnd/base.py
+++ b/src/transformnd/base.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from copy import copy
-from typing import Iterator, List, Optional, Sequence, Set, Union
+from typing import Iterator, List, Optional, Sequence, Set, Union, Generic
 
 import numpy as np
+from array_api_compat import array_namespace
 
 from .util import (
     SpaceRef,
@@ -17,10 +18,12 @@ from .util import (
     space_str,
     window,
     SpaceTuple,
+    ArrayT,
+    Namespace
 )
 
 
-class Transform(ABC):
+class Transform(ABC, Generic[ArrayT]):
     """Base class for transforms."""
 
     ndim: Optional[Set[int]] = None
@@ -47,14 +50,14 @@ class Transform(ABC):
     def target_space(self):
         return self.spaces[1]
 
-    def _validate_coords(self, coords) -> np.ndarray:
+    def _validate_coords(self, coords: ArrayT) -> ArrayT:
         """Check that dimension of coords are supported.
 
-        Also ensure that coords is a 2D numpy array.
+        Also ensure that coords is a 2D array.
 
         Parameters
         ----------
-        coords : np.ndarray
+        coords : ArrayT
             NxD array of N D-dimensional coordinates.
 
         Raises
@@ -62,19 +65,19 @@ class Transform(ABC):
         ValueError
             If dimensions are not supported.
         """
-        coords = np.asarray(coords)
-        if coords.ndim != 2:
+        xp = array_namespace(coords)
+        if xp.ndim(coords) != 2:
             raise ValueError("Coords must be a 2D array")
-        check_ndim(coords.shape[1], self.ndim)
+        check_ndim(xp.shape(coords)[1], self.ndim)
         return coords
 
     @abstractmethod
-    def apply(self, coords: np.ndarray) -> np.ndarray:
+    def apply(self, coords: ArrayT) -> ArrayT:
         """Apply transformation.
 
         Parameters
         ----------
-        coords : np.ndarray
+        coords : ArrayT
             NxD array of N D-dimensional coordinates.
 
         Returns
@@ -212,12 +215,12 @@ def get_transform_list(t: Transform) -> List[Transform]:
         return [t]
 
 
-class TransformSequence(Transform, Sequence[Transform]):
+class TransformSequence(Transform[ArrayT], Sequence[Transform[ArrayT]]):
     """Chain transforms, applying one after another."""
 
     def __init__(
         self,
-        transforms: Sequence[Transform],
+        transforms: Sequence[Transform[ArrayT]],
         *,
         spaces: SpaceTuple = (None, None),
     ) -> None:
@@ -228,7 +231,7 @@ class TransformSequence(Transform, Sequence[Transform]):
 
         Parameters
         ----------
-        transforms : List[Transform]
+        transforms : List[Transform[ArrayT]]
             Items which are a TransformSequences
             will each still be treated as a single transform.
         spaces : tuple[SpaceRef, SpaceRef]
@@ -286,7 +289,7 @@ class TransformSequence(Transform, Sequence[Transform]):
             spaces=(self.spaces[1], self.spaces[0]),
         )
 
-    def apply(self, coords: np.ndarray) -> np.ndarray:
+    def apply(self, coords: ArrayT) -> ArrayT:
         for t in self.transforms:
             coords = t.apply(coords)
         return coords

--- a/src/transformnd/base.py
+++ b/src/transformnd/base.py
@@ -320,6 +320,11 @@ class TransformSequence(Transform[ArrayT], Sequence[Transform[ArrayT]]):
             coords = t.apply(coords)
         return coords
 
+    def to_device(self, xp, device=None) -> Self:
+        result = copy(self)
+        result.transforms = [t.to_device(xp, device) for t in self.transforms]
+        return result
+
     def list_spaces(self, skip_none=False) -> list[SpaceRef]:
         """List spaces in this transform.
 

--- a/src/transformnd/graph.py
+++ b/src/transformnd/graph.py
@@ -171,3 +171,10 @@ class TransformGraph(Generic[ArrayT]):
         """
         for _, _, t in self.graph.edges.data("transform"):
             yield t
+
+    def to_device(self, xp, device=None) -> "TransformGraph[ArrayT]":
+        result = TransformGraph()
+        result.ndim = self.ndim
+        for src, tgt, t in self.graph.edges.data("transform"):
+            result.graph.add_edge(src, tgt, transform=t.to_device(xp, device))
+        return result

--- a/src/transformnd/graph.py
+++ b/src/transformnd/graph.py
@@ -173,7 +173,7 @@ class TransformGraph(Generic[ArrayT]):
             yield t
 
     def to_device(self, xp, device=None) -> "TransformGraph[ArrayT]":
-        result = TransformGraph()
+        result: TransformGraph[ArrayT] = TransformGraph()
         result.ndim = self.ndim
         for src, tgt, t in self.graph.edges.data("transform"):
             result.graph.add_edge(src, tgt, transform=t.to_device(xp, device))

--- a/src/transformnd/graph.py
+++ b/src/transformnd/graph.py
@@ -1,6 +1,5 @@
 """Bridging transforms between known spaces."""
 
-from typing import Generic
 from functools import lru_cache
 from collections.abc import Iterable, Iterator
 
@@ -37,7 +36,7 @@ def split_sequence(seq: TransformSequence) -> Iterator[Transform]:
             this_seq = []
 
 
-class TransformGraph(Generic[ArrayT]):
+class TransformGraph[ArrayT]:
     """Transform between any number of arbitrary spaces/ coordinate systems.
 
     Finds the shortest path for transforming one space

--- a/src/transformnd/graph.py
+++ b/src/transformnd/graph.py
@@ -1,7 +1,7 @@
 """Bridging transforms between known spaces."""
 
 from functools import lru_cache
-from typing import Dict, Iterable, Iterator, Optional, Set, Tuple
+from collections.abc import Iterable, Iterator
 
 import networkx as nx
 
@@ -47,7 +47,7 @@ class TransformGraph:
 
     def __init__(self):
         self.graph = nx.DiGraph()
-        self.ndim: Optional[Set[int]] = None
+        self.ndim: set[int] | None = None
 
     def add_transforms(self, transforms: Iterable[Transform]):
         """
@@ -64,7 +64,7 @@ class TransformGraph:
             Undefined source and target spaces.
         """
         # TODO: weighting of split-out sequences could be problematic
-        edges: Dict[Tuple[SpaceRef, SpaceRef], Transform] = dict()
+        edges: dict[tuple[SpaceRef, SpaceRef], Transform] = dict()
         self.get_sequence.cache_clear()
 
         ndim = self.ndim
@@ -80,7 +80,7 @@ class TransformGraph:
                 ts = [t]
 
             for t2 in ts:
-                if chain_or(t.source_space, t.target_space, default=None) is None:
+                if chain_or(t2.source_space, t2.target_space, default=None) is None:
                     raise ValueError(
                         "All transforms in a graph "
                         "need explicit source and target spaces"

--- a/src/transformnd/graph.py
+++ b/src/transformnd/graph.py
@@ -4,10 +4,9 @@ from functools import lru_cache
 from typing import Dict, Iterable, Iterator, Optional, Set, Tuple
 
 import networkx as nx
-import numpy as np
 
 from .base import Transform, TransformSequence
-from .util import SpaceRef, chain_or, dim_intersection, window
+from .util import SpaceRef, chain_or, dim_intersection, window, ArrayT
 
 
 def split_sequence(seq: TransformSequence) -> Iterator[Transform]:
@@ -132,8 +131,8 @@ class TransformGraph:
         )
 
     def transform(
-        self, source_space: SpaceRef, target_space: SpaceRef, coords: np.ndarray
-    ) -> np.ndarray:
+        self, source_space: SpaceRef, target_space: SpaceRef, coords: ArrayT
+    ) -> ArrayT:
         """Transform coordinates from one space to another,
         possibly via intermediates.
 
@@ -141,11 +140,11 @@ class TransformGraph:
         ----------
         source_space : SpaceRef
         target_space : SpaceRef
-        coords : np.ndarray
+        coords : ArrayT
 
         Returns
         -------
-        np.ndarray
+        ArrayT
         """
         t = self.get_sequence(source_space, target_space)
         return t.apply(coords)

--- a/src/transformnd/graph.py
+++ b/src/transformnd/graph.py
@@ -1,5 +1,6 @@
 """Bridging transforms between known spaces."""
 
+from typing import Generic
 from functools import lru_cache
 from collections.abc import Iterable, Iterator
 
@@ -36,7 +37,7 @@ def split_sequence(seq: TransformSequence) -> Iterator[Transform]:
             this_seq = []
 
 
-class TransformGraph:
+class TransformGraph(Generic[ArrayT]):
     """Transform between any number of arbitrary spaces/ coordinate systems.
 
     Finds the shortest path for transforming one space
@@ -49,11 +50,11 @@ class TransformGraph:
         self.graph = nx.DiGraph()
         self.ndim: set[int] | None = None
 
-    def add_transforms(self, transforms: Iterable[Transform]):
+    def add_transforms(self, transforms: Iterable[Transform[ArrayT]]) -> int:
         """
         Parameters
         ----------
-        transforms : Iterable[Transform]
+        transforms : Iterable[Transform[ArrayT]]
             Transforms which must have a source and target space defined.
             TransformSequences are split out if their inner transforms'
             spaces are defined.
@@ -64,7 +65,7 @@ class TransformGraph:
             Undefined source and target spaces.
         """
         # TODO: weighting of split-out sequences could be problematic
-        edges: dict[tuple[SpaceRef, SpaceRef], Transform] = dict()
+        edges: dict[tuple[SpaceRef, SpaceRef], Transform[ArrayT]] = dict()
         self.get_sequence.cache_clear()
 
         ndim = self.ndim
@@ -106,7 +107,7 @@ class TransformGraph:
     @lru_cache()
     def get_sequence(
         self, source_space: SpaceRef, target_space: SpaceRef
-    ) -> TransformSequence:
+    ) -> TransformSequence[ArrayT]:
         """Get the shortest TransformSequence for transforming between two spaces.
 
         Parameters
@@ -116,7 +117,7 @@ class TransformGraph:
 
         Returns
         -------
-        TransformSequence
+        TransformSequence[ArrayT]
         """
         path = nx.shortest_path(self.graph, source_space, target_space)
         if len(path) <= 1:
@@ -149,7 +150,7 @@ class TransformGraph:
         t = self.get_sequence(source_space, target_space)
         return t.apply(coords)
 
-    def __iter__(self) -> Iterator[Transform]:
+    def __iter__(self) -> Iterator[Transform[ArrayT]]:
         """Iterate through the transforms present in the graph.
 
         Includes inferred reverse transforms.
@@ -159,7 +160,7 @@ class TransformGraph:
 
         Yields
         -------
-        Transform
+        Transform[ArrayT]
 
         Examples
         --------

--- a/src/transformnd/transforms/affine.py
+++ b/src/transformnd/transforms/affine.py
@@ -94,9 +94,9 @@ class Affine(Transform[ArrayT]):
         coords = xp.asarray(coords)
         m = xp.asarray(self.matrix, device=d)
         coords = xp.concatenate(
-            [coords, xp.ones((coords.shape[0], 1), dtype=coords.dtype)], axis=1
+            [coords, xp.ones((coords.shape[0], 1), dtype=coords.dtype)], axis=1  # type: ignore[attr-defined]
         )
-        out: ArrayT = (m @ coords.T).T[:, :-1]
+        out: ArrayT = (m @ coords.T).T[:, :-1]  # type: ignore[attr-defined]
         return out
 
     def __invert__(self) -> Transform:

--- a/src/transformnd/transforms/affine.py
+++ b/src/transformnd/transforms/affine.py
@@ -94,8 +94,8 @@ class Affine(Transform[ArrayT]):
         coords = xp.asarray(coords)
         m = xp.asarray(self.matrix, device=d)
         coords = xp.concatenate(
-            [coords, xp.ones((coords.shape[0], 1), dtype=coords.dtype)],
-            axis=1,  # type: ignore[attr-defined]
+            [coords, xp.ones((coords.shape[0], 1), dtype=coords.dtype)],  # type: ignore[attr-defined]
+            axis=1,
         )
         out: ArrayT = (m @ coords.T).T[:, :-1]  # type: ignore[attr-defined]
         return out

--- a/src/transformnd/transforms/affine.py
+++ b/src/transformnd/transforms/affine.py
@@ -4,33 +4,49 @@ Rigid transformations implemented as affine multiplications.
 
 from __future__ import annotations
 
+import math
 from typing import Container, Optional, Tuple, Union
 
 import numpy as np
 from numpy.typing import ArrayLike
 
+from copy import copy
+
 from array_api_compat import array_namespace
+from array_api_compat import device as xp_device
 from ..base import Transform, ArrayT
-from ..util import is_square, none_eq, SpaceTuple, Namespace
+from ..util import is_square, none_eq, SpaceTuple
 
 
-def arg_as_array(arg: ArrayT, ndim: Optional[int], name_space: Optional[Namespace] = None) -> ArrayT:
-    if name_space is None:
-        name_space = np
-    if name_space.isscalar(arg):
+def arg_as_array(arg, ndim: Optional[int]) -> np.ndarray:
+    """Convert a scalar or array-like argument to a 1-D NumPy array.
+
+    Parameters
+    ----------
+    arg :
+        Scalar (broadcast to ndim) or array-like.
+    ndim : int, optional
+        Required length. If arg is scalar, used to broadcast.
+    """
+    if isinstance(arg, (int, float, complex)):
         if ndim is None:
             raise ValueError("Argument must be array-like or ndim must be given")
-        return name_space.full(ndim, arg)
-    arr = name_space.asarray(arg)
+        return np.full(ndim, arg)
+    arr = np.asarray(arg)
     if ndim is not None and len(arr) != ndim:
         raise ValueError("Mismatch between ndim and length of argument")
     return arr
 
 
 class Affine(Transform[ArrayT]):
-    """Affine transformation using an augmented matrix."""
-    m: ArrayT
-    
+    """Affine transformation using an augmented matrix.
+
+    The transformation matrix is stored as a NumPy array (backend-neutral).
+    At apply()-time it is converted to the input coords' backend and device,
+    so the transform works transparently with NumPy, JAX, PyTorch, CuPy, etc.
+    """
+    matrix: np.ndarray
+
     def __init__(
         self,
         matrix: ArrayLike,
@@ -44,7 +60,8 @@ class Affine(Transform[ArrayT]):
         Parameters
         ----------
         matrix : ArrayLike
-            Affine transformation matrix.
+            Affine transformation matrix. Any array-like (including JAX/PyTorch
+            arrays) is accepted and converted to NumPy for storage.
         spaces : tuple[SpaceRef, SpaceRef]
             Optional source and target spaces
 
@@ -54,14 +71,13 @@ class Affine(Transform[ArrayT]):
             Malformed matrix.
         """
         super().__init__(spaces=spaces)
-        xp = array_namespace(matrix)
-        m = xp.asarray(matrix)
+        m = np.asarray(matrix)
 
         if m.ndim != 2:
             raise ValueError("Transformation matrix must be 2D")
-    
+
         if m.shape[1] == m.shape[0] + 1:
-            base = xp.eye(m.shape[1])
+            base = np.eye(m.shape[1], dtype=m.dtype)
             base[:-1, :] = m
             m = base
         elif not is_square(m):
@@ -72,19 +88,19 @@ class Affine(Transform[ArrayT]):
 
     def apply(self, coords: ArrayT) -> ArrayT:
         coords = self._validate_coords(coords)
-        # todo: replace with writing into full ones?
         xp = array_namespace(coords)
+        d = xp_device(coords)
         coords = xp.asarray(coords)
+        m = xp.asarray(self.matrix, device=d)
         coords = xp.concatenate(
             [coords, xp.ones((coords.shape[0], 1), dtype=coords.dtype)], axis=1
         )
-        out: ArrayT = (self.matrix @ coords.T).T[:, :-1]
+        out: ArrayT = (m @ coords.T).T[:, :-1]
         return out
 
     def __invert__(self) -> Transform:
-        xp = array_namespace(self.matrix)
         return type(self)(
-            xp.linalg.inv(self.matrix),
+            np.linalg.inv(self.matrix),
             spaces=(self.spaces[1], self.spaces[0]),
         )
 
@@ -112,16 +128,37 @@ class Affine(Transform[ArrayT]):
             )
         if not none_eq(self.target_space, rhs.source_space):
             raise ValueError("Affine transforms do not share a space")
-        xp = array_namespace(self.matrix)
         return Affine(
-            xp.matmul(self.matrix, rhs.matrix),
+            self.matrix @ rhs.matrix,
             spaces=(self.source_space, rhs.target_space),
         )
+
+    def to_device(self, xp, device=None) -> "Affine[ArrayT]":
+        """Return a copy with the matrix placed on the given device/backend.
+
+        Use this before a tight apply() loop to avoid per-call host-to-device
+        transfers when coords live on GPU.
+
+        Parameters
+        ----------
+        xp : array namespace
+            Target array namespace (e.g. jax.numpy, torch).
+        device : device object, optional
+            Target device (e.g. from array_api_compat.device(array)).
+
+        Returns
+        -------
+        Affine
+            New instance with matrix on the target device.
+        """
+        result = copy(self)
+        result.matrix = xp.asarray(self.matrix, device=device)
+        return result
 
     @classmethod
     def from_linear_map(
         cls,
-        linear_map: ArrayT,
+        linear_map: ArrayLike,
         translation=0,
         *,
         spaces: SpaceTuple = (None, None),
@@ -131,10 +168,10 @@ class Affine(Transform[ArrayT]):
 
         Parameters
         ----------
-        linear_map : ArrayT
+        linear_map : ArrayLike
             Shape (D, D)
-        translation : ArrayT, optional
-            Translation to add to the matrix, by default None
+        translation : ArrayLike, optional
+            Translation to add to the matrix, by default 0
         spaces : tuple[SpaceRef, SpaceRef]
             Optional source and target spaces
 
@@ -142,14 +179,11 @@ class Affine(Transform[ArrayT]):
         -------
         AffineTransform
         """
-        xp = array_namespace(linear_map)
-        lin_map = xp.asarray(linear_map)
-
+        lin_map = np.asarray(linear_map)
         side = len(lin_map) + 1
-        matrix = xp.eye(side, dtype=lin_map.dtype)
-        matrix[:-1, :] = lin_map
+        matrix = np.eye(side, dtype=lin_map.dtype)
+        matrix[:-1, :-1] = lin_map
         matrix[:-1, -1] = translation
-
         return cls(matrix, spaces=spaces)
 
     @classmethod
@@ -158,7 +192,6 @@ class Affine(Transform[ArrayT]):
         ndim: int,
         *,
         spaces: SpaceTuple = (None, None),
-        name_space: Optional[Namespace] = None,
     ) -> Affine[ArrayT]:
         """Create an identity affine transformation.
 
@@ -172,17 +205,12 @@ class Affine(Transform[ArrayT]):
         -------
         AffineTransform
         """
-        if name_space is None:
-            name_space = np
-        return cls(
-            name_space.eye(ndim + 1),
-            spaces=spaces,
-        )
+        return cls(np.eye(ndim + 1), spaces=spaces)
 
     @classmethod
     def translation(
         cls,
-        translation: ArrayT,
+        translation: ArrayLike,
         ndim: Optional[int] = None,
         *,
         spaces: SpaceTuple = (None, None),
@@ -203,25 +231,23 @@ class Affine(Transform[ArrayT]):
         AffineTransform
         """
         t = arg_as_array(translation, ndim)
-        xp = array_namespace(t)
-        m = xp.eye(len(t) + 1, dtype=t.dtype)
+        m = np.eye(len(t) + 1, dtype=t.dtype)
         m[:-1, -1] = t
-
         return cls(m, spaces=spaces)
 
     @classmethod
     def scaling(
         cls,
-        scale: ArrayT,
+        scale: ArrayLike,
         ndim: Optional[int] = None,
         *,
         spaces: SpaceTuple = (None, None),
-    ) -> Affine:
+    ) -> Affine[ArrayT]:
         """Create an affine scaling.
 
         Parameters
         ----------
-        scale : ArrayT
+        scale : ArrayLike
             If scalar, broadcast to ndim.
         ndim : Optional[int], optional
             If scale is scalar, how many dimensions to use
@@ -231,13 +257,10 @@ class Affine(Transform[ArrayT]):
         Returns
         -------
         AffineTransform
-            [description]
         """
         s = arg_as_array(scale, ndim)
-        xp = array_namespace(s)
-        m = xp.eye(len(s) + 1, dtype=s.dtype)
+        m = np.eye(len(s) + 1, dtype=s.dtype)
         m[:-1, :-1] *= s
-
         return cls(m, spaces=spaces)
 
     @classmethod
@@ -247,7 +270,6 @@ class Affine(Transform[ArrayT]):
         ndim: int,
         *,
         spaces: SpaceTuple = (None, None),
-        name_space: Optional[Namespace] = None,
     ) -> Affine[ArrayT]:
         """Create an affine reflection.
 
@@ -264,16 +286,10 @@ class Affine(Transform[ArrayT]):
         -------
         AffineTransform
         """
-        if np.isscalar(axis):
+        if isinstance(axis, (int, np.integer)):
             axis = [axis]
-        values = [-1 if idx in axis else 1 for idx in range(ndim)]  # type:ignore
-        if name_space is None:
-            name_space = np
-        values = name_space.asarray(values)
-        m = name_space.eye(ndim + 1)
-        m[:-1, :-1] *= values
-
-        return cls(m, spaces=spaces)
+        values = np.asarray([-1 if idx in axis else 1 for idx in range(ndim)])
+        return cls.from_linear_map(np.diag(values.astype(float)), spaces=spaces)
 
     @classmethod
     def rotation2(
@@ -283,7 +299,6 @@ class Affine(Transform[ArrayT]):
         clockwise=False,
         *,
         spaces: SpaceTuple = (None, None),
-        name_space: Optional[Namespace] = None,
     ) -> Affine[ArrayT]:
         """Create a 2D affine rotation.
 
@@ -303,19 +318,11 @@ class Affine(Transform[ArrayT]):
         AffineTransform
         """
         if degrees:
-            rotation = np.deg2rad(rotation)
+            rotation = math.radians(rotation)
         if clockwise:
             rotation *= -1
-
-        vals = [
-            [np.cos(rotation), -np.sin(rotation)],
-            [np.sin(rotation), np.cos(rotation)],
-        ]
-        m = np.eye(3)
-        m[:-1, :-1] = vals
-        if name_space is not None:
-            m = name_space.asarray(m)
-        return cls(m, spaces=spaces)
+        c, s = math.cos(rotation), math.sin(rotation)
+        return cls.from_linear_map(np.array([[c, -s], [s, c]]), spaces=spaces)
 
     @classmethod
     def rotation3(
@@ -326,7 +333,6 @@ class Affine(Transform[ArrayT]):
         order=(0, 1, 2),
         *,
         spaces: SpaceTuple = (None, None),
-        name_space: Optional[Namespace] = None,
     ) -> Affine[ArrayT]:
         """Create a 3D affine rotation.
 
@@ -352,64 +358,39 @@ class Affine(Transform[ArrayT]):
         ValueError
             Incompatible order.
         """
-        if np.isscalar(rotation):
-            r = np.array([rotation] * 3)
+        if isinstance(rotation, (int, float)):
+            r = [rotation] * 3
         else:
-            r = np.asarray(rotation)
+            r = list(rotation)
 
         if degrees:
-            r = np.deg2rad(r)
+            r = [math.radians(x) for x in r]
         if clockwise:
-            r *= -1
+            r = [-x for x in r]
 
         if len(order) != 3 or set(order) != {0, 1, 2}:
             raise ValueError("Order must contain only 0, 1, 2 in any order.")
 
         order = list(order)
+        c0, s0 = math.cos(r[0]), math.sin(r[0])
+        c1, s1 = math.cos(r[1]), math.sin(r[1])
+        c2, s2 = math.cos(r[2]), math.sin(r[2])
 
         rots = [
-            np.array(
-                [
-                    [1, 0, 0],
-                    [0, np.cos(r[0]), -np.sin(r[0])],
-                    [0, np.sin(r[0]), np.cos(r[0])],
-                ]
-            ),
-            np.array(
-                [
-                    [np.cos(r[1]), 0, np.sin(r[1])],
-                    [0, 1, 0],
-                    [-np.sin(r[1]), 0, np.cos(r[1])],
-                ]
-            ),
-            np.array(
-                [
-                    [np.cos(r[2]), -np.sin(r[2]), 0],
-                    [np.sin(r[2]), np.cos(r[2]), 0],
-                    [0, 0, 1],
-                ]
-            ),
+            np.array([[1, 0, 0], [0, c0, -s0], [0, s0, c0]]),
+            np.array([[c1, 0, s1], [0, 1, 0], [-s1, 0, c1]]),
+            np.array([[c2, -s2, 0], [s2, c2, 0], [0, 0, 1]]),
         ]
-
-        rot = rots[order.pop(0)]
-        rot @= rots[order.pop(0)]
-        rot @= rots[order.pop(0)]
-
-        m = np.eye(4)
-        m[:-1, :-1] = rot
-
-        if name_space is not None:
-            m = name_space.asarray(m)
-        return cls(m, spaces=spaces)
+        rot = rots[order[0]] @ rots[order[1]] @ rots[order[2]]
+        return cls.from_linear_map(rot, spaces=spaces)
 
     @classmethod
     def shearing(
         cls,
-        factor: Union[float, Namespace],
+        factor: Union[float, np.ndarray],
         ndim: Optional[int] = None,
         *,
         spaces: SpaceTuple = (None, None),
-        name_space: Optional[Namespace] = None,
     ) -> Affine[ArrayT]:
         """Create an affine shear.
 
@@ -438,25 +419,22 @@ class Affine(Transform[ArrayT]):
         ValueError
             Incompatible factor.
         """
-        if np.isscalar(factor):
+        if isinstance(factor, (int, float, complex)):
             if ndim is None:
                 raise ValueError("If factor is scalar, ndim must be defined")
             s = np.full((ndim, ndim - 1), factor)
-            name_space = array_namespace(s)
         else:
-            name_space = array_namespace(factor)
-            s = name_space.asarray(factor)
-            if s.shape[0] != s.shape[1] + 1:
+            s = np.asarray(factor)
+            if s.ndim != 2 or s.shape[0] != s.shape[1] + 1:
                 raise ValueError("Factor must be of shape (D, D-1)")
             ndim = s.shape[0]
 
-        # needed for type checking
         assert ndim is not None
 
-        m = name_space.eye(ndim, dtype=s.dtype)
+        m = np.eye(ndim, dtype=s.dtype)
         for col_idx in range(m.shape[1]):
-            it = iter(factor[col_idx])  # type: ignore
+            it = iter(s[col_idx])
             for row_idx in range(m.shape[0] - 1):
                 if m[row_idx, col_idx] == 0:
                     m[row_idx, col_idx] = next(it)
-        return cls(m, spaces=spaces)
+        return cls.from_linear_map(m, spaces=spaces)

--- a/src/transformnd/transforms/affine.py
+++ b/src/transformnd/transforms/affine.py
@@ -9,24 +9,28 @@ from typing import Container, Optional, Tuple, Union
 import numpy as np
 from numpy.typing import ArrayLike
 
-from ..base import Transform
-from ..util import is_square, none_eq, SpaceTuple
+from array_api_compat import array_namespace
+from ..base import Transform, ArrayT
+from ..util import is_square, none_eq, SpaceTuple, Namespace
 
 
-def arg_as_array(arg: ArrayLike, ndim: Optional[int]):
-    if np.isscalar(arg):
+def arg_as_array(arg: ArrayT, ndim: Optional[int], name_space: Optional[Namespace] = None) -> ArrayT:
+    if name_space is None:
+        name_space = np
+    if name_space.isscalar(arg):
         if ndim is None:
             raise ValueError("Argument must be array-like or ndim must be given")
-        return np.full(ndim, arg)
-    arr = np.asarray(arg)
+        return name_space.full(ndim, arg)
+    arr = name_space.asarray(arg)
     if ndim is not None and len(arr) != ndim:
         raise ValueError("Mismatch between ndim and length of argument")
     return arr
 
 
-class Affine(Transform):
+class Affine(Transform[ArrayT]):
     """Affine transformation using an augmented matrix."""
-
+    m: ArrayT
+    
     def __init__(
         self,
         matrix: ArrayLike,
@@ -50,13 +54,14 @@ class Affine(Transform):
             Malformed matrix.
         """
         super().__init__(spaces=spaces)
-        m = np.asarray(matrix)
+        xp = array_namespace(matrix)
+        m = xp.asarray(matrix)
 
         if m.ndim != 2:
             raise ValueError("Transformation matrix must be 2D")
-
+    
         if m.shape[1] == m.shape[0] + 1:
-            base = np.eye(m.shape[1])
+            base = xp.eye(m.shape[1])
             base[:-1, :] = m
             m = base
         elif not is_square(m):
@@ -65,21 +70,25 @@ class Affine(Transform):
         self.matrix = m
         self.ndim = {len(self.matrix) - 1}
 
-    def apply(self, coords: np.ndarray) -> np.ndarray:
+    def apply(self, coords: ArrayT) -> ArrayT:
         coords = self._validate_coords(coords)
         # todo: replace with writing into full ones?
-        coords = np.concatenate(
-            [coords, np.ones((coords.shape[0], 1), dtype=coords.dtype)], axis=1
+        xp = array_namespace(coords)
+        coords = xp.asarray(coords)
+        coords = xp.concatenate(
+            [coords, xp.ones((coords.shape[0], 1), dtype=coords.dtype)], axis=1
         )
-        return (self.matrix @ coords.T).T[:, :-1]
+        out: ArrayT = (self.matrix @ coords.T).T[:, :-1]
+        return out
 
     def __invert__(self) -> Transform:
+        xp = array_namespace(self.matrix)
         return type(self)(
-            np.linalg.inv(self.matrix),
+            xp.linalg.inv(self.matrix),
             spaces=(self.spaces[1], self.spaces[0]),
         )
 
-    def __matmul__(self, rhs: Affine) -> Affine:
+    def __matmul__(self, rhs: Affine[ArrayT]) -> Affine[ArrayT]:
         """Compose two affine transforms by matrix multiplication.
 
         Parameters
@@ -103,27 +112,28 @@ class Affine(Transform):
             )
         if not none_eq(self.target_space, rhs.source_space):
             raise ValueError("Affine transforms do not share a space")
+        xp = array_namespace(self.matrix)
         return Affine(
-            self.matrix @ rhs.matrix,
+            xp.matmul(self.matrix, rhs.matrix),
             spaces=(self.source_space, rhs.target_space),
         )
 
     @classmethod
     def from_linear_map(
         cls,
-        linear_map: ArrayLike,
+        linear_map: ArrayT,
         translation=0,
         *,
         spaces: SpaceTuple = (None, None),
-    ) -> Affine:
+    ) -> Affine[ArrayT]:
         """Create an augmented affine matrix from a linear map,
         with an optional translation.
 
         Parameters
         ----------
-        linear_map : ArrayLike
+        linear_map : ArrayT
             Shape (D, D)
-        translation : ArrayLike, optional
+        translation : ArrayT, optional
             Translation to add to the matrix, by default None
         spaces : tuple[SpaceRef, SpaceRef]
             Optional source and target spaces
@@ -132,10 +142,11 @@ class Affine(Transform):
         -------
         AffineTransform
         """
-        lin_map = np.asarray(linear_map)
+        xp = array_namespace(linear_map)
+        lin_map = xp.asarray(linear_map)
 
         side = len(lin_map) + 1
-        matrix = np.eye(side, dtype=lin_map.dtype)
+        matrix = xp.eye(side, dtype=lin_map.dtype)
         matrix[:-1, :] = lin_map
         matrix[:-1, -1] = translation
 
@@ -147,7 +158,8 @@ class Affine(Transform):
         ndim: int,
         *,
         spaces: SpaceTuple = (None, None),
-    ) -> Affine:
+        name_space: Optional[Namespace] = None,
+    ) -> Affine[ArrayT]:
         """Create an identity affine transformation.
 
         Parameters
@@ -160,19 +172,21 @@ class Affine(Transform):
         -------
         AffineTransform
         """
+        if name_space is None:
+            name_space = np
         return cls(
-            np.eye(ndim + 1),
+            name_space.eye(ndim + 1),
             spaces=spaces,
         )
 
     @classmethod
     def translation(
         cls,
-        translation: ArrayLike,
+        translation: ArrayT,
         ndim: Optional[int] = None,
         *,
         spaces: SpaceTuple = (None, None),
-    ) -> Affine:
+    ) -> Affine[ArrayT]:
         """Create an affine translation.
 
         Parameters
@@ -189,7 +203,8 @@ class Affine(Transform):
         AffineTransform
         """
         t = arg_as_array(translation, ndim)
-        m = np.eye(len(t) + 1, dtype=t.dtype)
+        xp = array_namespace(t)
+        m = xp.eye(len(t) + 1, dtype=t.dtype)
         m[:-1, -1] = t
 
         return cls(m, spaces=spaces)
@@ -197,7 +212,7 @@ class Affine(Transform):
     @classmethod
     def scaling(
         cls,
-        scale: ArrayLike,
+        scale: ArrayT,
         ndim: Optional[int] = None,
         *,
         spaces: SpaceTuple = (None, None),
@@ -206,7 +221,7 @@ class Affine(Transform):
 
         Parameters
         ----------
-        scale : ArrayLike
+        scale : ArrayT
             If scalar, broadcast to ndim.
         ndim : Optional[int], optional
             If scale is scalar, how many dimensions to use
@@ -219,7 +234,8 @@ class Affine(Transform):
             [description]
         """
         s = arg_as_array(scale, ndim)
-        m = np.eye(len(s) + 1, dtype=s.dtype)
+        xp = array_namespace(s)
+        m = xp.eye(len(s) + 1, dtype=s.dtype)
         m[:-1, :-1] *= s
 
         return cls(m, spaces=spaces)
@@ -231,7 +247,8 @@ class Affine(Transform):
         ndim: int,
         *,
         spaces: SpaceTuple = (None, None),
-    ) -> Affine:
+        name_space: Optional[Namespace] = None,
+    ) -> Affine[ArrayT]:
         """Create an affine reflection.
 
         Parameters
@@ -248,9 +265,12 @@ class Affine(Transform):
         AffineTransform
         """
         if np.isscalar(axis):
-            axis = [axis]  # type: ignore
+            axis = [axis]
         values = [-1 if idx in axis else 1 for idx in range(ndim)]  # type:ignore
-        m = np.eye(ndim + 1)
+        if name_space is None:
+            name_space = np
+        values = name_space.asarray(values)
+        m = name_space.eye(ndim + 1)
         m[:-1, :-1] *= values
 
         return cls(m, spaces=spaces)
@@ -263,7 +283,8 @@ class Affine(Transform):
         clockwise=False,
         *,
         spaces: SpaceTuple = (None, None),
-    ) -> Affine:
+        name_space: Optional[Namespace] = None,
+    ) -> Affine[ArrayT]:
         """Create a 2D affine rotation.
 
         Parameters
@@ -292,7 +313,8 @@ class Affine(Transform):
         ]
         m = np.eye(3)
         m[:-1, :-1] = vals
-
+        if name_space is not None:
+            m = name_space.asarray(m)
         return cls(m, spaces=spaces)
 
     @classmethod
@@ -304,7 +326,8 @@ class Affine(Transform):
         order=(0, 1, 2),
         *,
         spaces: SpaceTuple = (None, None),
-    ) -> Affine:
+        name_space: Optional[Namespace] = None,
+    ) -> Affine[ArrayT]:
         """Create a 3D affine rotation.
 
         Parameters
@@ -375,16 +398,19 @@ class Affine(Transform):
         m = np.eye(4)
         m[:-1, :-1] = rot
 
+        if name_space is not None:
+            m = name_space.asarray(m)
         return cls(m, spaces=spaces)
 
     @classmethod
     def shearing(
         cls,
-        factor: Union[float, np.ndarray],
+        factor: Union[float, Namespace],
         ndim: Optional[int] = None,
         *,
         spaces: SpaceTuple = (None, None),
-    ) -> Affine:
+        name_space: Optional[Namespace] = None,
+    ) -> Affine[ArrayT]:
         """Create an affine shear.
 
         `factor` can be a scalar to broadcast to all dimensions,
@@ -416,8 +442,10 @@ class Affine(Transform):
             if ndim is None:
                 raise ValueError("If factor is scalar, ndim must be defined")
             s = np.full((ndim, ndim - 1), factor)
+            name_space = array_namespace(s)
         else:
-            s = np.asarray(factor)
+            name_space = array_namespace(factor)
+            s = name_space.asarray(factor)
             if s.shape[0] != s.shape[1] + 1:
                 raise ValueError("Factor must be of shape (D, D-1)")
             ndim = s.shape[0]
@@ -425,11 +453,10 @@ class Affine(Transform):
         # needed for type checking
         assert ndim is not None
 
-        m = np.eye(ndim, dtype=s.dtype)
+        m = name_space.eye(ndim, dtype=s.dtype)
         for col_idx in range(m.shape[1]):
             it = iter(factor[col_idx])  # type: ignore
             for row_idx in range(m.shape[0] - 1):
                 if m[row_idx, col_idx] == 0:
                     m[row_idx, col_idx] = next(it)
-
         return cls(m, spaces=spaces)

--- a/src/transformnd/transforms/affine.py
+++ b/src/transformnd/transforms/affine.py
@@ -94,7 +94,8 @@ class Affine(Transform[ArrayT]):
         coords = xp.asarray(coords)
         m = xp.asarray(self.matrix, device=d)
         coords = xp.concatenate(
-            [coords, xp.ones((coords.shape[0], 1), dtype=coords.dtype)], axis=1  # type: ignore[attr-defined]
+            [coords, xp.ones((coords.shape[0], 1), dtype=coords.dtype)],
+            axis=1,  # type: ignore[attr-defined]
         )
         out: ArrayT = (m @ coords.T).T[:, :-1]  # type: ignore[attr-defined]
         return out

--- a/src/transformnd/transforms/affine.py
+++ b/src/transformnd/transforms/affine.py
@@ -45,6 +45,7 @@ class Affine(Transform[ArrayT]):
     At apply()-time it is converted to the input coords' backend and device,
     so the transform works transparently with NumPy, JAX, PyTorch, CuPy, etc.
     """
+
     matrix: np.ndarray
 
     def __init__(

--- a/src/transformnd/transforms/map_axis.py
+++ b/src/transformnd/transforms/map_axis.py
@@ -4,7 +4,7 @@ from ..base import Transform
 from ..util import SpaceTuple
 
 
-class MapAxis(Transform):
+class MapAxis(Transform[np.ndarray]):
     """Map coordinates from one axis to another.
 
     For example, x -> y and y -> x"""
@@ -38,12 +38,12 @@ class MapAxis(Transform):
         """
         return coords[:, self.permutation]
 
-    def __invert__(self) -> Transform:
+    def __invert__(self) -> Transform[np.ndarray]:
         """Invert transformation if possible.
 
         Returns
         -------
-        Transform
+        Transform[np.ndarray]
             Inverted transformation.
         """
         return type(self)(

--- a/src/transformnd/transforms/moving_least_squares.py
+++ b/src/transformnd/transforms/moving_least_squares.py
@@ -11,7 +11,7 @@ from ..base import SpaceTuple, Transform
 from ..util import invert_spaces
 
 
-class MovingLeastSquares(Transform):
+class MovingLeastSquares(Transform[np.ndarray]):
     """Moving least squares transformation.
 
     Deform based on a matched pairs of source and target control points; see <https://dl.acm.org/doi/10.1145/1141911.1141920>

--- a/src/transformnd/transforms/reflection.py
+++ b/src/transformnd/transforms/reflection.py
@@ -118,7 +118,7 @@ class Reflect(Transform[np.ndarray]):
             and len(n1) != len(point)
         ):
             raise ValueError("Point and normals are not of the same dimensionality")
-        self.point = point
+        self.point: np.ndarray = np.asarray(point, dtype=float)
         self.ndim = {len(n1)}
         self.normals = [unitise(n) for n in normals]
         # todo: matmul is associative, so turn this into an affine in 2/3D?

--- a/src/transformnd/transforms/reflection.py
+++ b/src/transformnd/transforms/reflection.py
@@ -85,7 +85,7 @@ class Reflect(Transform[np.ndarray]):
     def __init__(
         self,
         normals: ArrayLike,
-        point=0,
+        point: float | ArrayLike = 0.,
         *,
         spaces: SpaceTuple = (None, None),
     ):
@@ -95,7 +95,7 @@ class Reflect(Transform[np.ndarray]):
         normals : sequence of arrays
             Normal vectors to the planes of reflection.
             Unitised internally.
-        point : float or sequence of floats, optional
+        point : float or array-like, optional
             Intersection point of all reflection planes
             (can be broadcast from scalar), by default 0 (i.e. the origin)
         spaces : tuple[SpaceRef, SpaceRef]
@@ -112,7 +112,7 @@ class Reflect(Transform[np.ndarray]):
             normals = [normals]
 
         n1 = normals[0]
-        if not np.isscalar(point) and len(n1) != len(point):
+        if not np.isscalar(point) and isinstance(point, Sequence) and len(n1) != len(point):
             raise ValueError("Point and normals are not of the same dimensionality")
         self.point = point
         self.ndim = {len(n1)}
@@ -140,7 +140,7 @@ class Reflect(Transform[np.ndarray]):
 
         Parameters
         ----------
-        points :
+        points : array-like
             NxD array of N points in D dimensions. N == D
         spaces : tuple[SpaceRef, SpaceRef]
             Optional source and target spaces

--- a/src/transformnd/transforms/reflection.py
+++ b/src/transformnd/transforms/reflection.py
@@ -1,5 +1,5 @@
+from collections.abc import Sequence
 from copy import copy
-from typing import List, Sequence, Tuple, Union
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -8,18 +8,18 @@ from ..base import SpaceTuple, Transform
 from ..util import is_square
 
 
-def proj(u, v):
+def proj(u: np.ndarray, v: np.ndarray) -> np.ndarray:
     return (np.inner(u, v) / np.inner(u, u)) * u
 
 
-def gram_schmidt(vecs: np.ndarray):
+def gram_schmidt(vecs: np.ndarray) -> np.ndarray:
     """
     https://en.wikipedia.org/wiki/Gram%E2%80%93Schmidt_process
     """
     if not is_square(vecs):
         raise ValueError("Wrong number of dimensions")
 
-    out: List[np.ndarray] = []
+    out: list[np.ndarray] = []
     for v in vecs:
         b = v.copy()
 
@@ -30,7 +30,9 @@ def gram_schmidt(vecs: np.ndarray):
     return np.array(out)
 
 
-def get_hyperplanes(points: np.ndarray, unitise=True, seed=None):
+def get_hyperplanes(
+    points: np.ndarray, unitise: bool = True, seed: int | None = None
+) -> tuple[np.ndarray, list[np.ndarray]]:
     """
     Reflective: point/line/.../hyperplane to be reflected around
 
@@ -67,15 +69,14 @@ def get_hyperplanes(points: np.ndarray, unitise=True, seed=None):
     return point, list(extras)
 
 
-def unitise(v):
+def unitise(v: np.ndarray) -> np.ndarray:
     return v / np.linalg.norm(v)
 
 
-def ensure_tuple(obj) -> Tuple:
-    try:
-        return tuple(obj)
-    except TypeError:
+def ensure_tuple(obj: int | Sequence[int]) -> tuple[int, ...]:
+    if isinstance(obj, int):
         return (obj,)
+    return tuple(obj)
 
 
 class Reflect(Transform[np.ndarray]):
@@ -154,7 +155,7 @@ class Reflect(Transform[np.ndarray]):
     @classmethod
     def from_axis(
         cls,
-        axis: Union[int, Sequence[int]],
+        axis: int | Sequence[int],
         origin: ArrayLike,
         *,
         spaces: SpaceTuple = (None, None),

--- a/src/transformnd/transforms/reflection.py
+++ b/src/transformnd/transforms/reflection.py
@@ -85,7 +85,7 @@ class Reflect(Transform[np.ndarray]):
     def __init__(
         self,
         normals: ArrayLike,
-        point: float | ArrayLike = 0.,
+        point: float | ArrayLike = 0.0,
         *,
         spaces: SpaceTuple = (None, None),
     ):
@@ -112,7 +112,11 @@ class Reflect(Transform[np.ndarray]):
             normals = [normals]
 
         n1 = normals[0]
-        if not np.isscalar(point) and isinstance(point, Sequence) and len(n1) != len(point):
+        if (
+            not np.isscalar(point)
+            and isinstance(point, Sequence)
+            and len(n1) != len(point)
+        ):
             raise ValueError("Point and normals are not of the same dimensionality")
         self.point = point
         self.ndim = {len(n1)}

--- a/src/transformnd/transforms/reflection.py
+++ b/src/transformnd/transforms/reflection.py
@@ -78,7 +78,7 @@ def ensure_tuple(obj) -> Tuple:
         return (obj,)
 
 
-class Reflect(Transform):
+class Reflect(Transform[np.ndarray]):
     """Reflect coordinates about arbitrary planes."""
 
     def __init__(

--- a/src/transformnd/transforms/simple.py
+++ b/src/transformnd/transforms/simple.py
@@ -3,6 +3,7 @@ Simple transformations like rigid translation and scaling.
 """
 
 from copy import copy
+from typing import Self
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -10,7 +11,7 @@ from numpy.typing import ArrayLike
 from array_api_compat import array_namespace
 from array_api_compat import device as xp_device
 from ..base import Transform
-from ..util import chain_or, SpaceTuple, invert_spaces
+from ..util import ArrayT, chain_or, SpaceTuple, invert_spaces
 
 
 class Identity(Transform):
@@ -43,7 +44,7 @@ class Identity(Transform):
     def __invert__(self) -> Transform:
         return self
 
-    def apply(self, coords):
+    def apply(self, coords: ArrayT) -> ArrayT:
         xp = array_namespace(coords)
         return xp.asarray(coords, copy=True)
 
@@ -80,7 +81,7 @@ class Translate(Transform):
             self.ndim = {self.translation.shape[0]}
         # otherwise, can be broadcast to anything
 
-    def apply(self, coords):
+    def apply(self, coords: ArrayT) -> ArrayT:
         coords = self._validate_coords(coords)
         xp = array_namespace(coords)
         d = xp_device(coords)
@@ -89,7 +90,7 @@ class Translate(Transform):
     def __invert__(self) -> Transform:
         return type(self)(-self.translation, spaces=(self.spaces[1], self.spaces[0]))
 
-    def to_device(self, xp, device=None) -> "Translate":
+    def to_device(self, xp, device=None) -> Self:
         result = copy(self)
         result.translation = xp.asarray(self.translation, device=device)
         return result
@@ -129,7 +130,7 @@ class Scale(Transform):
             self.ndim = {self.scale.shape[0]}
         # otherwise, can be broadcast to anything
 
-    def apply(self, coords):
+    def apply(self, coords: ArrayT) -> ArrayT:
         coords = self._validate_coords(coords)
         xp = array_namespace(coords)
         d = xp_device(coords)
@@ -141,7 +142,7 @@ class Scale(Transform):
             spaces=invert_spaces(self.spaces),
         )
 
-    def to_device(self, xp, device=None) -> "Scale":
+    def to_device(self, xp, device=None) -> Self:
         result = copy(self)
         result.scale = xp.asarray(self.scale, device=device)
         return result

--- a/src/transformnd/transforms/simple.py
+++ b/src/transformnd/transforms/simple.py
@@ -2,9 +2,13 @@
 Simple transformations like rigid translation and scaling.
 """
 
+from copy import copy
+
 import numpy as np
 from numpy.typing import ArrayLike
 
+from array_api_compat import array_namespace
+from array_api_compat import device as xp_device
 from ..base import Transform
 from ..util import chain_or, SpaceTuple, invert_spaces
 
@@ -39,8 +43,9 @@ class Identity(Transform):
     def __invert__(self) -> Transform:
         return self
 
-    def apply(self, coords: np.ndarray) -> np.ndarray:
-        return coords.copy()
+    def apply(self, coords):
+        xp = array_namespace(coords)
+        return xp.asarray(coords, copy=True)
 
 
 class Translate(Transform):
@@ -75,12 +80,19 @@ class Translate(Transform):
             self.ndim = {self.translation.shape[0]}
         # otherwise, can be broadcast to anything
 
-    def apply(self, coords: np.ndarray) -> np.ndarray:
-        self._validate_coords(coords)
-        return coords + self.translation
+    def apply(self, coords):
+        coords = self._validate_coords(coords)
+        xp = array_namespace(coords)
+        d = xp_device(coords)
+        return coords + xp.asarray(self.translation, device=d)
 
     def __invert__(self) -> Transform:
         return type(self)(-self.translation, spaces=(self.spaces[1], self.spaces[0]))
+
+    def to_device(self, xp, device=None) -> "Translate":
+        result = copy(self)
+        result.translation = xp.asarray(self.translation, device=device)
+        return result
 
 
 class Scale(Transform):
@@ -117,12 +129,19 @@ class Scale(Transform):
             self.ndim = {self.scale.shape[0]}
         # otherwise, can be broadcast to anything
 
-    def apply(self, coords: np.ndarray) -> np.ndarray:
+    def apply(self, coords):
         coords = self._validate_coords(coords)
-        return coords * self.scale
+        xp = array_namespace(coords)
+        d = xp_device(coords)
+        return coords * xp.asarray(self.scale, device=d)
 
     def __invert__(self) -> Transform:
         return type(self)(
             1 / self.scale,
             spaces=invert_spaces(self.spaces),
         )
+
+    def to_device(self, xp, device=None) -> "Scale":
+        result = copy(self)
+        result.scale = xp.asarray(self.scale, device=device)
+        return result

--- a/src/transformnd/transforms/simple.py
+++ b/src/transformnd/transforms/simple.py
@@ -14,7 +14,7 @@ from ..base import Transform
 from ..util import ArrayT, chain_or, SpaceTuple, invert_spaces
 
 
-class Identity(Transform):
+class Identity(Transform[ArrayT]):
     """No-op transformation."""
 
     def __init__(
@@ -41,15 +41,15 @@ class Identity(Transform):
             raise ValueError("Source and target spaces are different")
         super().__init__(spaces=(src, src))
 
-    def __invert__(self) -> Transform:
+    def __invert__(self) -> Transform[ArrayT]:
         return self
 
     def apply(self, coords: ArrayT) -> ArrayT:
         xp = array_namespace(coords)
-        return xp.asarray(coords, copy=True)
+        return xp.asarray(coords)
 
 
-class Translate(Transform):
+class Translate(Transform[ArrayT]):
     """Translate coordinates by addition."""
 
     def __init__(
@@ -96,7 +96,7 @@ class Translate(Transform):
         return result
 
 
-class Scale(Transform):
+class Scale(Transform[ArrayT]):
     """Scale coordinates by multiplication."""
 
     def __init__(

--- a/src/transformnd/transforms/thinplate.py
+++ b/src/transformnd/transforms/thinplate.py
@@ -25,7 +25,7 @@ except ImportError:
     )
 
 
-class ThinPlateSplines(Transform):
+class ThinPlateSplines(Transform[np.ndarray]):
     """Thin plate splines transforms.
 
     Deform based on matched pairs of control points.
@@ -78,7 +78,7 @@ class ThinPlateSplines(Transform):
             self.target_control_points,
         )
 
-    def __invert__(self) -> Transform:
+    def __invert__(self) -> Transform[np.ndarray]:
         return type(self)(
             self.target_control_points,
             self.source_control_points,

--- a/src/transformnd/transforms/thinplate.py
+++ b/src/transformnd/transforms/thinplate.py
@@ -18,7 +18,7 @@ try:
     from scipy.spatial.distance import cdist
 
     # Replace morphops's original slow distance_matrix function
-    mops.lmk_util.distance_matrix = cdist # type: ignore
+    mops.lmk_util.distance_matrix = cdist  # type: ignore
 except ImportError:
     logger.warning(
         "scipy not present; morphops-based transformations may be slower than necessary"

--- a/src/transformnd/transforms/thinplate.py
+++ b/src/transformnd/transforms/thinplate.py
@@ -18,7 +18,7 @@ try:
     from scipy.spatial.distance import cdist
 
     # Replace morphops's original slow distance_matrix function
-    mops.lmk_util.distance_matrix = cdist
+    mops.lmk_util.distance_matrix = cdist # type: ignore
 except ImportError:
     logger.warning(
         "scipy not present; morphops-based transformations may be slower than necessary"

--- a/src/transformnd/util.py
+++ b/src/transformnd/util.py
@@ -11,13 +11,17 @@ from typing import (
     Optional,
     Set,
     Tuple,
+    TypeVar,
 )
 
-import numpy as np
+from array_api_compat import array_namespace
+from array_api_compat.common._typing import Namespace
 
 UNSPECIFIED_SPACE_NAME = "???"
 
-TransformSignature = Callable[[np.ndarray], np.ndarray]
+ArrayT = TypeVar("ArrayT")
+
+TransformSignature = Callable[[ArrayT], ArrayT]
 """Type annotation of a function which can be used as a transform."""
 
 SpaceRef = Hashable
@@ -192,8 +196,10 @@ def space_str(space: Optional[SpaceRef]):
         return str(space)
 
 
-def is_square(arr: np.ndarray) -> bool:
-    return arr.ndim == 2 and arr.shape[0] == arr.shape[1]
+def is_square(arr: ArrayT) -> bool:
+    xp = array_namespace(arr)
+    ndim, shape = xp.ndim(arr), xp.shape(arr)
+    return ndim == 2 and shape[0] == shape[1]
 
 
 def dim_intersection(dims1: Optional[Set[int]], dims2: Optional[Set[int]]):

--- a/src/transformnd/util.py
+++ b/src/transformnd/util.py
@@ -5,7 +5,6 @@ from collections.abc import Callable, Hashable, Iterable, Iterator
 from typing import Any, TypeVar
 
 from array_api_compat import array_namespace
-from array_api_compat.common._typing import Namespace
 
 UNSPECIFIED_SPACE_NAME = "???"
 

--- a/src/transformnd/util.py
+++ b/src/transformnd/util.py
@@ -1,18 +1,8 @@
 """Utilities used elsewhere in the package."""
 
 from collections import deque
-from typing import (
-    Any,
-    Callable,
-    Deque,
-    Hashable,
-    Iterable,
-    Iterator,
-    Optional,
-    Set,
-    Tuple,
-    TypeVar,
-)
+from collections.abc import Callable, Hashable, Iterable, Iterator
+from typing import Any, TypeVar
 
 from array_api_compat import array_namespace
 from array_api_compat.common._typing import Namespace
@@ -27,10 +17,10 @@ TransformSignature = Callable[[ArrayT], ArrayT]
 SpaceRef = Hashable
 """Type annotation of things which can be used to refer to spaces"""
 
-SpaceTuple = Tuple[Optional[SpaceRef], Optional[SpaceRef]]
+SpaceTuple = tuple[SpaceRef | None, SpaceRef | None]
 
 
-def none_eq(a: Optional[Any], b: Optional[Any]) -> bool:
+def none_eq(a: Any | None, b: Any | None) -> bool:
     """Check whether either is None or both are equal.
 
     Parameters
@@ -48,7 +38,7 @@ def none_eq(a: Optional[Any], b: Optional[Any]) -> bool:
 NO_DEFAULT = object()
 
 
-def chain_or(*args: Optional[Any], default=NO_DEFAULT):
+def chain_or(*args: Any | None, default=NO_DEFAULT) -> Any:
     """Return the first of *args which is not None.
 
     Can either error or return a default if there are no non-None args.
@@ -77,7 +67,7 @@ def chain_or(*args: Optional[Any], default=NO_DEFAULT):
     return default
 
 
-def same_or_none(*args, default=NO_DEFAULT):
+def same_or_none(*args: Any, default=NO_DEFAULT) -> Any:
     """Check args are the same or None.
 
     If so, return the non-None value.
@@ -118,7 +108,7 @@ def same_or_none(*args, default=NO_DEFAULT):
     return prev
 
 
-def window(iterable: Iterable, length: int) -> Iterator[Tuple[Any, ...]]:
+def window(iterable: Iterable, length: int) -> Iterator[tuple[Any, ...]]:
     """Sliding window over iterable.
 
     e.g. `(it[0], it[1]), (it[1], it[2]), (it[2], it[3]), ...`
@@ -134,7 +124,7 @@ def window(iterable: Iterable, length: int) -> Iterator[Tuple[Any, ...]]:
     Tuple[Any, ...]
     """
     it = iter(iterable)
-    q: Deque[Any] = deque(maxlen=length)
+    q: deque[Any] = deque(maxlen=length)
     for _ in range(length):
         try:
             item = next(it)
@@ -147,7 +137,7 @@ def window(iterable: Iterable, length: int) -> Iterator[Tuple[Any, ...]]:
         yield tuple(q)
 
 
-def check_ndim(given_ndim: int, supported_ndim: Optional[Set[int]]):
+def check_ndim(given_ndim: int, supported_ndim: set[int] | None) -> None:
     """Raise a ValueError if dimensionality is unsupported.
 
     Parameters
@@ -169,7 +159,7 @@ def check_ndim(given_ndim: int, supported_ndim: Optional[Set[int]]):
         )
 
 
-def format_dims(supported):
+def format_dims(supported: set[int] | None) -> str:
     """Format supported dimensions for e.g. error messages.
 
     Parameters
@@ -189,7 +179,7 @@ def format_dims(supported):
     return "/".join(f"{d}D" for d in sorted(supported))
 
 
-def space_str(space: Optional[SpaceRef]):
+def space_str(space: SpaceRef | None) -> str:
     if space is None:
         return UNSPECIFIED_SPACE_NAME
     else:
@@ -202,7 +192,7 @@ def is_square(arr: ArrayT) -> bool:
     return ndim == 2 and shape[0] == shape[1]
 
 
-def dim_intersection(dims1: Optional[Set[int]], dims2: Optional[Set[int]]):
+def dim_intersection(dims1: set[int] | None, dims2: set[int] | None) -> set[int] | None:
     if dims1 is None:
         return dims2
     elif dims2 is None:

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -74,7 +74,7 @@ def test_add():
 
 
 def test_maths():
-    t1 = Translate(1)
+    t1 = Translate[np.ndarray](1)
     coords = np.zeros((5, 3))
 
     assert np.allclose((t1 | ~t1).apply(coords), coords)

--- a/tests/transforms/test_affine.py
+++ b/tests/transforms/test_affine.py
@@ -5,7 +5,7 @@ from transformnd.transforms.affine import Affine
 
 
 def test_identity():
-    i2 = Affine.identity(2)
+    i2 = Affine[np.ndarray].identity(2)
     test = np.array([(1, 1), (2, 3), (-2, 50)])
     ref = test.copy()
     assert np.allclose(i2.apply(test), ref)
@@ -18,8 +18,8 @@ def test_translation(ndim, rng):
 
     coords = rng.random((5, ndim)) - 0.5
     t_arr = [t] * ndim
-    trans = Affine.translation(t, ndim)
-    trans_arr = Affine.translation(t_arr)
+    trans = Affine[np.ndarray].translation(t, ndim)
+    trans_arr = Affine[np.ndarray].translation(t_arr)
     assert np.allclose(trans.apply(coords), coords + t)
     assert np.allclose(trans_arr.apply(coords), coords + t)
     assert np.allclose((~trans).apply(coords), coords - t)
@@ -30,17 +30,17 @@ def test_scaling(ndim, rng):
     s = 2
 
     coords = rng.random((5, ndim)) - 0.5
-    trans = Affine.scaling(s, ndim)
+    trans = Affine[np.ndarray].scaling(s, ndim)
     assert np.allclose(trans.apply(coords), coords * s)
     assert np.allclose((~trans).apply(coords), coords / s)
 
     t_arr = [s] * ndim
-    trans_arr = Affine.scaling(t_arr)
+    trans_arr = Affine[np.ndarray].scaling(t_arr)
     assert np.allclose(trans_arr.apply(coords), coords * s)
 
 
 def test_rotation2():
-    rot90 = Affine.rotation2(90)
+    rot90 = Affine[np.ndarray].rotation2(90)
     coords = np.array([[1, 1]])
     expected = np.array([[-1, 1], [-1, -1], [1, -1], [1, 1]])
     for exp in expected:

--- a/tests/transforms/test_simple.py
+++ b/tests/transforms/test_simple.py
@@ -5,7 +5,7 @@ from transformnd.transforms.simple import Identity, Scale, Translate
 
 
 def test_identity_spaces():
-    t = Identity(spaces=(1, 1))
+    t = Identity[np.ndarray](spaces=(1, 1))
     assert t.target_space == 1
 
     with pytest.raises(ValueError):
@@ -13,13 +13,13 @@ def test_identity_spaces():
 
 
 def test_translate_nd(coords5x3):
-    t = Translate(1)
+    t = Translate[np.ndarray](1)
     assert np.allclose(t.apply(coords5x3), coords5x3 + 1)
 
 
 def test_translate_3d(coords5x3):
     trans = [1, 2, 3]
-    t = Translate(np.array(trans))
+    t = Translate[np.ndarray](np.array(trans))
     assert np.allclose(t.apply(coords5x3), coords5x3 + trans)
 
 
@@ -29,13 +29,13 @@ def test_translate_neg(coords5x3):
 
 
 def test_scale_nd(coords5x3):
-    t = Scale(2)
+    t = Scale[np.ndarray](2)
     assert np.allclose(t.apply(coords5x3), coords5x3 * 2)
 
 
 def test_scale_3d(coords5x3):
     scale = [2, 3, 4]
-    t = Scale(np.array(scale))
+    t = Scale[np.ndarray](np.array(scale))
     assert np.allclose(t.apply(coords5x3), coords5x3 * scale)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -5,9 +5,12 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
     "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version < '3.14' and sys_platform == 'emscripten'",
-    "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version < '3.13' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
 [[package]]
@@ -21,6 +24,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "array-api-compat"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/e5/9a12dd1c2b0ad61f3c3ad0fc14b888c65fd735dd9d26805f77317303cbe5/array_api_compat-1.14.0.tar.gz", hash = "sha256:c819ba707f5c507800cb545f7e6348ff1ecc46538381d9ad9b371ffc9cd6d784", size = 106369, upload-time = "2026-02-26T12:02:42.452Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/d3/54cd560804a8c2b898824778e86c13c2a14600bc83532a9c4f69f2f469c3/array_api_compat-1.14.0-py3-none-any.whl", hash = "sha256:ed5af1f9b6595a199c942505f281ec994892556b6efc24679a0501e87a7d6279", size = 60124, upload-time = "2026-02-26T12:02:41.127Z" },
 ]
 
 [[package]]
@@ -260,6 +272,52 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
+]
+
+[[package]]
+name = "jax"
+version = "0.9.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jaxlib" },
+    { name = "ml-dtypes" },
+    { name = "numpy" },
+    { name = "opt-einsum" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/92/4c/5aca25abd45fa38dd136e5ae2010376518c67950e1f9408e0c5c93fcf77d/jax-0.9.2.tar.gz", hash = "sha256:42b28017b3e6b57a44b0274cc15f5153239c4873959030399ac1afc009c22365", size = 2662784, upload-time = "2026-03-18T23:28:10.471Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/9c/e897231c880f69e32251d3b1145894d7a04e4342d9bef8d29644c440d11b/jax-0.9.2-py3-none-any.whl", hash = "sha256:822a8ae155ab42e7bc59f2ae7a28705bcfccb01a7e76abfc8ae996190cdc5598", size = 3099142, upload-time = "2026-03-18T23:25:59.94Z" },
+]
+
+[[package]]
+name = "jaxlib"
+version = "0.9.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ml-dtypes" },
+    { name = "numpy" },
+    { name = "scipy" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/15/ff3d9fde15b5146a0164505085312d8c9c0b0bbd7be5a15218ead2593307/jaxlib-0.9.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:97c2fbe58cbee4a27d94ca735d709d231b299ab6ed8b3b1075f52d864dfd32c1", size = 58770928, upload-time = "2026-03-18T23:27:08.94Z" },
+    { url = "https://files.pythonhosted.org/packages/88/79/699aa47d2256b2edbb75a68a8f1a1ee4d34dfb84b8842a963caeb9a8cb03/jaxlib-0.9.2-cp312-cp312-manylinux_2_27_aarch64.whl", hash = "sha256:fef02d846863b726e72452993883a8596eac325f22a2ec7ea921da0fbc5509b4", size = 77733913, upload-time = "2026-03-18T23:27:12.927Z" },
+    { url = "https://files.pythonhosted.org/packages/33/a0/ddb3a71359c1df61f3edc408936b5bda7ed402e78ae7e9ef6afd438577c6/jaxlib-0.9.2-cp312-cp312-manylinux_2_27_x86_64.whl", hash = "sha256:88b276a71f4f2071b1fd2e922abfd67c87c6977a551a1036febcea78d5ef7e22", size = 83318134, upload-time = "2026-03-18T23:27:16.237Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/57/09d6a9e2a8bc8e3ea79eb8e980f8ea2aea2d9dec3793755f5765657f6e11/jaxlib-0.9.2-cp312-cp312-win_amd64.whl", hash = "sha256:c2f0837cc0788746301e68ae9eda468e6a8a7734dc4d529f26a2cb60fb56c657", size = 62846539, upload-time = "2026-03-18T23:27:19.869Z" },
+    { url = "https://files.pythonhosted.org/packages/09/d5/e5416c39e77eb1987479ef3b67930af9e78ecf65e7eb8a6cbe40b2aa0b66/jaxlib-0.9.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:52a0032508f8cf5791c7a7bee142531ee706c3c05518117fb0b6ee8d5e17fde7", size = 58772433, upload-time = "2026-03-18T23:27:23.188Z" },
+    { url = "https://files.pythonhosted.org/packages/56/57/f3d4bda9dcaae11f32fcbb29d7ecda1c36689b289f04b9e6902647876c0c/jaxlib-0.9.2-cp313-cp313-manylinux_2_27_aarch64.whl", hash = "sha256:bef61eef36ed38cec1069ea973f88af9e03335e884f6501ec3fe7f6222a1555b", size = 77736401, upload-time = "2026-03-18T23:27:26.387Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/52/203497d40f365a6b4f924ad49d93d226d6853b3ada198623c96c11500027/jaxlib-0.9.2-cp313-cp313-manylinux_2_27_x86_64.whl", hash = "sha256:b6d5003e3add5c346a34ae9edc47058cbc2db60c8ed5c50096522176daf01c9f", size = 83319274, upload-time = "2026-03-18T23:27:30.025Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/25/2d585ecf7cb4c982387b4f35ae6da8beb09d05665370bbff56b772e22925/jaxlib-0.9.2-cp313-cp313-win_amd64.whl", hash = "sha256:2d445dab57debd8c26b416c8bc91a4704ba6d7169788a961e4b15419bc3f4254", size = 62847296, upload-time = "2026-03-18T23:27:33.362Z" },
+    { url = "https://files.pythonhosted.org/packages/38/a9/a458a576f14c61de7a53105aa292acdb2f510352b44278dfe24b926f6d4a/jaxlib-0.9.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:6ffb22eccf07bfc8c9760bfbcdaa268df9b3745739e8397bfce5daee5d79cb51", size = 58880385, upload-time = "2026-03-18T23:27:36.297Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/10/7eb27c376691f7864becf27844b3c818f015e86e9f8390614c0048c2e62e/jaxlib-0.9.2-cp313-cp313t-manylinux_2_27_aarch64.whl", hash = "sha256:6949d7ecd869c117e7ea8361866e60cf229c3cd9d6afdc37425a43cf83fc89e9", size = 77849690, upload-time = "2026-03-18T23:27:39.943Z" },
+    { url = "https://files.pythonhosted.org/packages/80/e0/0bc84ff53bbc599a9925fa7017a226c646de6569ba1871b36694af8e200a/jaxlib-0.9.2-cp313-cp313t-manylinux_2_27_x86_64.whl", hash = "sha256:e8e8165f0f647933f0ff9e1e4d9937d541841d3672a20db73f5ccb5e842b0edc", size = 83427722, upload-time = "2026-03-18T23:27:43.391Z" },
+    { url = "https://files.pythonhosted.org/packages/75/06/aa1e2c36db1ed893ea4a89528a9cc8617a31919ffe7307c4f56aaa87e5cc/jaxlib-0.9.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:bab168d25555464461bd077323484f690c471e69ce8b0c39a39fb81b3e3a8bf0", size = 58776023, upload-time = "2026-03-18T23:27:46.907Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/ed/7f2cd3c9d91c95457f503311be4bc648b3a4aa79bfe1c874b16fa54c2207/jaxlib-0.9.2-cp314-cp314-manylinux_2_27_aarch64.whl", hash = "sha256:be4627c42d44add7fe17d284ef579ff8d159e3cb6947f6437758f34177e878e6", size = 77748670, upload-time = "2026-03-18T23:27:50.009Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/a1/461f25959e9eb0a46722d00c01cfb1dd82e8889dfa1c228f13e0cfbe948d/jaxlib-0.9.2-cp314-cp314-manylinux_2_27_x86_64.whl", hash = "sha256:3d7151140a4936f3218b2d1b1343dd237bd2865cf51442884b6d82fe884a3de7", size = 83330703, upload-time = "2026-03-18T23:27:54.578Z" },
+    { url = "https://files.pythonhosted.org/packages/21/98/34a9d156f61777abd9d4e74781fcd99fcf1bb77533e617c2d0ee1c5602fe/jaxlib-0.9.2-cp314-cp314-win_amd64.whl", hash = "sha256:87bd42c9f18c9cc9a45371d02ecdbdb574ea1e2277149601a92e14a24c4bbc86", size = 65247657, upload-time = "2026-03-18T23:27:57.855Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/c9/5653eb4be25a3235be2606e1e8fb28fb8c6f0f48b33b947e47f0dc7e7ec0/jaxlib-0.9.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b8998f9fa6e67bf956044c310023f6a7bbfaa0d8955f11d928404c8f6eb02fcf", size = 58882789, upload-time = "2026-03-18T23:28:00.834Z" },
+    { url = "https://files.pythonhosted.org/packages/41/8d/ef12f6a2f158d47480cded343c85078a02e9fc7d4952dafcd95dab6f9127/jaxlib-0.9.2-cp314-cp314t-manylinux_2_27_aarch64.whl", hash = "sha256:35b473df72dbc2cfda0cb1b3de7521a2150a0aa5ef57ed7583eeceb012dc17c0", size = 77850880, upload-time = "2026-03-18T23:28:04.063Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/6a/6dff1e6e3f9d918bc777e087091bdefbd7d33328c1d1b152429c6cdcf723/jaxlib-0.9.2-cp314-cp314t-manylinux_2_27_x86_64.whl", hash = "sha256:bbe59bdef668ff5fd998c6d88e8df9a32ab95bec0dea3d2b5f7a11b86a9a6788", size = 83425685, upload-time = "2026-03-18T23:28:07.906Z" },
 ]
 
 [[package]]
@@ -663,6 +721,42 @@ wheels = [
 ]
 
 [[package]]
+name = "ml-dtypes"
+version = "0.5.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/4a/c27b42ed9b1c7d13d9ba8b6905dece787d6259152f2309338aed29b2447b/ml_dtypes-0.5.4.tar.gz", hash = "sha256:8ab06a50fb9bf9666dd0fe5dfb4676fa2b0ac0f31ecff72a6c3af8e22c063453", size = 692314, upload-time = "2025-11-17T22:32:31.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/b8/3c70881695e056f8a32f8b941126cf78775d9a4d7feba8abcb52cb7b04f2/ml_dtypes-0.5.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a174837a64f5b16cab6f368171a1a03a27936b31699d167684073ff1c4237dac", size = 676927, upload-time = "2025-11-17T22:31:48.182Z" },
+    { url = "https://files.pythonhosted.org/packages/54/0f/428ef6881782e5ebb7eca459689448c0394fa0a80bea3aa9262cba5445ea/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a7f7c643e8b1320fd958bf098aa7ecf70623a42ec5154e3be3be673f4c34d900", size = 5028464, upload-time = "2025-11-17T22:31:50.135Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/cb/28ce52eb94390dda42599c98ea0204d74799e4d8047a0eb559b6fd648056/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9ad459e99793fa6e13bd5b7e6792c8f9190b4e5a1b45c63aba14a4d0a7f1d5ff", size = 5009002, upload-time = "2025-11-17T22:31:52.001Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/f0/0cfadd537c5470378b1b32bd859cf2824972174b51b873c9d95cfd7475a5/ml_dtypes-0.5.4-cp312-cp312-win_amd64.whl", hash = "sha256:c1a953995cccb9e25a4ae19e34316671e4e2edaebe4cf538229b1fc7109087b7", size = 212222, upload-time = "2025-11-17T22:31:53.742Z" },
+    { url = "https://files.pythonhosted.org/packages/16/2e/9acc86985bfad8f2c2d30291b27cd2bb4c74cea08695bd540906ed744249/ml_dtypes-0.5.4-cp312-cp312-win_arm64.whl", hash = "sha256:9bad06436568442575beb2d03389aa7456c690a5b05892c471215bfd8cf39460", size = 160793, upload-time = "2025-11-17T22:31:55.358Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/a1/4008f14bbc616cfb1ac5b39ea485f9c63031c4634ab3f4cf72e7541f816a/ml_dtypes-0.5.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8c760d85a2f82e2bed75867079188c9d18dae2ee77c25a54d60e9cc79be1bc48", size = 676888, upload-time = "2025-11-17T22:31:56.907Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b7/dff378afc2b0d5a7d6cd9d3209b60474d9819d1189d347521e1688a60a53/ml_dtypes-0.5.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ce756d3a10d0c4067172804c9cc276ba9cc0ff47af9078ad439b075d1abdc29b", size = 5036993, upload-time = "2025-11-17T22:31:58.497Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/33/40cd74219417e78b97c47802037cf2d87b91973e18bb968a7da48a96ea44/ml_dtypes-0.5.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:533ce891ba774eabf607172254f2e7260ba5f57bdd64030c9a4fcfbd99815d0d", size = 5010956, upload-time = "2025-11-17T22:31:59.931Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/8b/200088c6859d8221454825959df35b5244fa9bdf263fd0249ac5fb75e281/ml_dtypes-0.5.4-cp313-cp313-win_amd64.whl", hash = "sha256:f21c9219ef48ca5ee78402d5cc831bd58ea27ce89beda894428bc67a52da5328", size = 212224, upload-time = "2025-11-17T22:32:01.349Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/75/dfc3775cb36367816e678f69a7843f6f03bd4e2bcd79941e01ea960a068e/ml_dtypes-0.5.4-cp313-cp313-win_arm64.whl", hash = "sha256:35f29491a3e478407f7047b8a4834e4640a77d2737e0b294d049746507af5175", size = 160798, upload-time = "2025-11-17T22:32:02.864Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/74/e9ddb35fd1dd43b1106c20ced3f53c2e8e7fc7598c15638e9f80677f81d4/ml_dtypes-0.5.4-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:304ad47faa395415b9ccbcc06a0350800bc50eda70f0e45326796e27c62f18b6", size = 702083, upload-time = "2025-11-17T22:32:04.08Z" },
+    { url = "https://files.pythonhosted.org/packages/74/f5/667060b0aed1aa63166b22897fdf16dca9eb704e6b4bbf86848d5a181aa7/ml_dtypes-0.5.4-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6a0df4223b514d799b8a1629c65ddc351b3efa833ccf7f8ea0cf654a61d1e35d", size = 5354111, upload-time = "2025-11-17T22:32:05.546Z" },
+    { url = "https://files.pythonhosted.org/packages/40/49/0f8c498a28c0efa5f5c95a9e374c83ec1385ca41d0e85e7cf40e5d519a21/ml_dtypes-0.5.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:531eff30e4d368cb6255bc2328d070e35836aa4f282a0fb5f3a0cd7260257298", size = 5366453, upload-time = "2025-11-17T22:32:07.115Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/27/12607423d0a9c6bbbcc780ad19f1f6baa2b68b18ce4bddcdc122c4c68dc9/ml_dtypes-0.5.4-cp313-cp313t-win_amd64.whl", hash = "sha256:cb73dccfc991691c444acc8c0012bee8f2470da826a92e3a20bb333b1a7894e6", size = 225612, upload-time = "2025-11-17T22:32:08.615Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/80/5a5929e92c72936d5b19872c5fb8fc09327c1da67b3b68c6a13139e77e20/ml_dtypes-0.5.4-cp313-cp313t-win_arm64.whl", hash = "sha256:3bbbe120b915090d9dd1375e4684dd17a20a2491ef25d640a908281da85e73f1", size = 164145, upload-time = "2025-11-17T22:32:09.782Z" },
+    { url = "https://files.pythonhosted.org/packages/72/4e/1339dc6e2557a344f5ba5590872e80346f76f6cb2ac3dd16e4666e88818c/ml_dtypes-0.5.4-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:2b857d3af6ac0d39db1de7c706e69c7f9791627209c3d6dedbfca8c7e5faec22", size = 673781, upload-time = "2025-11-17T22:32:11.364Z" },
+    { url = "https://files.pythonhosted.org/packages/04/f9/067b84365c7e83bda15bba2b06c6ca250ce27b20630b1128c435fb7a09aa/ml_dtypes-0.5.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:805cef3a38f4eafae3a5bf9ebdcdb741d0bcfd9e1bd90eb54abd24f928cd2465", size = 5036145, upload-time = "2025-11-17T22:32:12.783Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/bb/82c7dcf38070b46172a517e2334e665c5bf374a262f99a283ea454bece7c/ml_dtypes-0.5.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14a4fd3228af936461db66faccef6e4f41c1d82fcc30e9f8d58a08916b1d811f", size = 5010230, upload-time = "2025-11-17T22:32:14.38Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/93/2bfed22d2498c468f6bcd0d9f56b033eaa19f33320389314c19ef6766413/ml_dtypes-0.5.4-cp314-cp314-win_amd64.whl", hash = "sha256:8c6a2dcebd6f3903e05d51960a8058d6e131fe69f952a5397e5dbabc841b6d56", size = 221032, upload-time = "2025-11-17T22:32:15.763Z" },
+    { url = "https://files.pythonhosted.org/packages/76/a3/9c912fe6ea747bb10fe2f8f54d027eb265db05dfb0c6335e3e063e74e6e8/ml_dtypes-0.5.4-cp314-cp314-win_arm64.whl", hash = "sha256:5a0f68ca8fd8d16583dfa7793973feb86f2fbb56ce3966daf9c9f748f52a2049", size = 163353, upload-time = "2025-11-17T22:32:16.932Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/02/48aa7d84cc30ab4ee37624a2fd98c56c02326785750cd212bc0826c2f15b/ml_dtypes-0.5.4-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:bfc534409c5d4b0bf945af29e5d0ab075eae9eecbb549ff8a29280db822f34f9", size = 702085, upload-time = "2025-11-17T22:32:18.175Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/e7/85cb99fe80a7a5513253ec7faa88a65306be071163485e9a626fce1b6e84/ml_dtypes-0.5.4-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2314892cdc3fcf05e373d76d72aaa15fda9fb98625effa73c1d646f331fcecb7", size = 5355358, upload-time = "2025-11-17T22:32:19.7Z" },
+    { url = "https://files.pythonhosted.org/packages/79/2b/a826ba18d2179a56e144aef69e57fb2ab7c464ef0b2111940ee8a3a223a2/ml_dtypes-0.5.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0d2ffd05a2575b1519dc928c0b93c06339eb67173ff53acb00724502cda231cf", size = 5366332, upload-time = "2025-11-17T22:32:21.193Z" },
+    { url = "https://files.pythonhosted.org/packages/84/44/f4d18446eacb20ea11e82f133ea8f86e2bf2891785b67d9da8d0ab0ef525/ml_dtypes-0.5.4-cp314-cp314t-win_amd64.whl", hash = "sha256:4381fe2f2452a2d7589689693d3162e876b3ddb0a832cde7a414f8e1adf7eab1", size = 236612, upload-time = "2025-11-17T22:32:22.579Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/3f/3d42e9a78fe5edf792a83c074b13b9b770092a4fbf3462872f4303135f09/ml_dtypes-0.5.4-cp314-cp314t-win_arm64.whl", hash = "sha256:11942cbf2cf92157db91e5022633c0d9474d4dfd813a909383bd23ce828a4b7d", size = 168825, upload-time = "2025-11-17T22:32:23.766Z" },
+]
+
+[[package]]
 name = "molesq"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -860,12 +954,21 @@ wheels = [
 ]
 
 [[package]]
-name = "packaging"
-version = "26.1"
+name = "opt-einsum"
+version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519, upload-time = "2026-04-14T21:12:49.362Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/b9/2ac072041e899a52f20cf9510850ff58295003aa75525e58343591b0cbfb/opt_einsum-3.4.0.tar.gz", hash = "sha256:96ca72f1b886d148241348783498194c577fa30a8faac108586b14f1ba4473ac", size = 63004, upload-time = "2024-09-26T14:33:24.483Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831, upload-time = "2026-04-14T21:12:47.56Z" },
+    { url = "https://files.pythonhosted.org/packages/23/cd/066e86230ae37ed0be70aae89aabf03ca8d9f39c8aea0dec8029455b5540/opt_einsum-3.4.0-py3-none-any.whl", hash = "sha256:69bb92469f86a1565195ece4ac0323943e83477171b91d24c35afe028a90d7cd", size = 71932, upload-time = "2024-09-26T14:33:23.039Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
 ]
 
 [[package]]
@@ -1413,6 +1516,7 @@ name = "transformnd"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "array-api-compat" },
     { name = "networkx" },
     { name = "numpy" },
 ]
@@ -1434,6 +1538,7 @@ thinplatesplines = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "jax" },
     { name = "marimo" },
     { name = "matplotlib" },
     { name = "mypy" },
@@ -1452,6 +1557,7 @@ lint = [
     { name = "ruff" },
 ]
 test = [
+    { name = "jax" },
     { name = "pytest" },
 ]
 tutorial = [
@@ -1462,6 +1568,7 @@ tutorial = [
 
 [package.metadata]
 requires-dist = [
+    { name = "array-api-compat", specifier = ">=1.14" },
     { name = "molesq", marker = "extra == 'movingleastsquares'", specifier = ">=0.4.0" },
     { name = "morphops", marker = "extra == 'thinplatesplines'", specifier = ">=0.1.13" },
     { name = "networkx", specifier = ">=3" },
@@ -1474,6 +1581,7 @@ provides-extras = ["thinplatesplines", "movingleastsquares", "pandas", "shapely"
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "jax" },
     { name = "marimo", specifier = ">=0.9" },
     { name = "matplotlib", specifier = ">=3.10.8" },
     { name = "mypy" },
@@ -1489,7 +1597,10 @@ lint = [
     { name = "prek", specifier = ">=0.3.9" },
     { name = "ruff" },
 ]
-test = [{ name = "pytest" }]
+test = [
+    { name = "jax" },
+    { name = "pytest" },
+]
 tutorial = [
     { name = "marimo", specifier = ">=0.9" },
     { name = "matplotlib", specifier = ">=3.10.8" },


### PR DESCRIPTION
This PR:
- Add supporting backend-agnostic array operations (including JAX and PyTorch) closes #2 
- Modernize type annotations.