### PR TITLE
Add simplify_affine and to_affine for affine chain collapsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ Open it with `uv run --group tutorial marimo edit examples/tutorial.py`.
 - Scale (`transformnd.transforms.Scale`)
 - Reflection (`transformnd.transforms.Reflect`)
 - Affine (`transformnd.transforms.Affine`)
-    - Can be composed efficiently with `@` operator
+  - Can be composed efficiently with `@` operator; the right hand operand is effectively applied first
 - MapAxis (`transformnd.transforms.MapAxis`): permute coordinate axes
 - ByDimension (`transformnd.transforms.ByDimension`): apply transformations to subsets of coordinate axes
 - Moving Least Squares, affine (`transformnd.transforms.moving_least_squares.MovingLeastSquares`)
-    - uses `movingleastsquares` extra
--   Thin Plate Splines (`transformnd.transforms.thinplate.ThinPlateSplines`)
-    - uses `thinplatesplines` extra
+  - uses `movingleastsquares` extra
+- Thin Plate Splines (`transformnd.transforms.thinplate.ThinPlateSplines`)
+  - uses `thinplatesplines` extra
 
 Arbitrary transforms can be composed into a `TransformSequence` with `transform1 | transform2`.
 A graph of transforms between defined spaces can be traversed using the `TransformGraph`.
@@ -54,7 +54,7 @@ A graph of transforms between defined spaces can be traversed using the `Transfo
 - Numpy arrays of shape `(..., D, ...)` (`transformnd.adapters.ReshapeAdapter`)
 - `meshio.Mesh` (`transformnd.adapters.meshio.MeshAdapter`)
 - `pandas.DataFrame` (`transformnd.adapters.pandas.DataFrameAdapter`)
-    - Takes a subset of columns as a coordinate array
+  - Takes a subset of columns as a coordinate array
 - Geometries from `shapely` (`transformnd.adapters.shapely.GeometryAdapter`)
 - Objects composed of transformable attributes (`transformnd.adapters.AttrAdapter`).
 
@@ -95,3 +95,12 @@ If the transformation's dimensionality is constrained by its parameters,
   - `prek install-hooks && prek run --all-files` to get started.
 - Use [`just`](https://github.com/casey/just) for common development tasks (format, lint, test, generate docs).
   - `just` to list commands.
+
+## Thanks
+
+Thanks to contributors
+
+- [Francesca Drummer](https://github.com/FrancescaDr)
+- [Lorenzo Cerrone](https://github.com/lorenzocerrone)
+- [Maks Hess](https://github.com/MaksHess)
+- [Silvia Maria Macrì](https://github.com/SilviaMariaMacri)

--- a/justfile
+++ b/justfile
@@ -18,6 +18,10 @@ lint:
     uv run mypy src tests
     uv run ruff format --check src tests examples
 
+fix:
+    uv run ruff check --fix src tests examples
+    uv run ruff format src tests examples
+
 # Format python code.
 format:
     uv run ruff format src tests examples

--- a/src/transformnd/base.py
+++ b/src/transformnd/base.py
@@ -49,8 +49,7 @@ class Transform[ArrayT](ABC):
     def target_space(self):
         return self.spaces[1]
 
-    @abstractmethod
-    def to_affine(self, dim: int | None = None) -> Optional[Transform]:
+    def to_affine(self, dim: int | None = None) -> Transform | None:
         """Convert the transform into affine, if conversion is possible.
 
         Parameters
@@ -64,7 +63,7 @@ class Transform[ArrayT](ABC):
             The affine transformation, if conversion is possible.
             None otherwise.
         """
-        pass
+        return None
 
     def _validate_coords(self, coords: ArrayT) -> ArrayT:
         """Check that dimension of coords are supported.
@@ -217,9 +216,6 @@ class TransformWrapper(Transform[ArrayT]):
     def apply(self, coords: ArrayT) -> ArrayT:
         self._validate_coords(coords)
         return self.fn(coords)
-
-    def to_affine(self, dim=None) -> None:
-        return None
 
 
 def _with_spaces(

--- a/src/transformnd/base.py
+++ b/src/transformnd/base.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Iterator, Sequence
 from copy import copy
-from typing import Self
+from typing import Self, Optional
 
 from array_api_compat import array_namespace
 
@@ -48,6 +48,23 @@ class Transform[ArrayT](ABC):
     @property
     def target_space(self):
         return self.spaces[1]
+
+    @abstractmethod
+    def to_affine(self, dim: int | None = None) -> Optional[Transform]:
+        """Convert the transform into affine, if conversion is possible.
+
+        Parameters
+        ----------
+        dim: int, optional
+            Total number of dimensions; If None, dim is set equal to self.ndim.
+
+        Returns
+        -------
+        Transform | None:
+            The affine transformation, if conversion is possible.
+            None otherwise.
+        """
+        pass
 
     def _validate_coords(self, coords: ArrayT) -> ArrayT:
         """Check that dimension of coords are supported.
@@ -201,6 +218,9 @@ class TransformWrapper(Transform[ArrayT]):
         self._validate_coords(coords)
         return self.fn(coords)
 
+    def to_affine(self, dim=None) -> None:
+        return None
+
 
 def _with_spaces(
     t: Transform[ArrayT],
@@ -350,3 +370,37 @@ class TransformSequence(Transform[ArrayT], Sequence[Transform[ArrayT]]):
         if isinstance(idx, int):
             return self.transforms[idx]
         return type(self)(self.transforms[idx])
+
+    def to_affine(self, dim=None) -> None:
+        return None
+
+    def simplify_affine(self, seq_dim: int | None = None):
+
+        if seq_dim is None:
+            for t in self.transforms:
+                if t.ndim:
+                    seq_dim = next(iter(t.ndim))
+                    break
+        out = []
+        affine = None
+        for t in self.transforms:
+            new_affine = t.to_affine(seq_dim)
+
+            if new_affine is None:
+                if affine is not None:
+                    out.append(affine)
+                affine = None
+                out.append(t)
+                continue
+
+            if affine is None:
+                affine = new_affine
+                continue
+            affine = affine @ new_affine  # type: ignore[operator]
+
+        if affine is not None:
+            out.append(affine)
+
+        self.transforms = out
+
+        return self

--- a/src/transformnd/base.py
+++ b/src/transformnd/base.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Iterator, Sequence
 from copy import copy
-from typing import Self, Optional
+from typing import Self, TYPE_CHECKING
 
 from array_api_compat import array_namespace
 
@@ -14,12 +14,17 @@ from .util import (
     TransformSignature,
     check_ndim,
     dim_intersection,
+    invert_spaces,
     same_or_none,
     space_str,
+    to_single_ndim,
     window,
     SpaceTuple,
     ArrayT,
 )
+
+if TYPE_CHECKING:
+    from .transforms import Affine
 
 
 class Transform[ArrayT](ABC):
@@ -32,8 +37,7 @@ class Transform[ArrayT](ABC):
         *,
         spaces: SpaceTuple = (None, None),
     ):
-        """Base class for transformations.
-
+        """
         Parameters
         ----------
         spaces : tuple[SpaceRef, SpaceRef]
@@ -49,7 +53,11 @@ class Transform[ArrayT](ABC):
     def target_space(self):
         return self.spaces[1]
 
-    def to_affine(self, dim: int | None = None) -> Transform | None:
+    def is_identity(self) -> bool:
+        """Whether this is a no-op transformation."""
+        return False
+
+    def to_affine(self, ndim: int | None = None) -> Affine[ArrayT] | None:
         """Convert the transform into affine, if conversion is possible.
 
         Parameters
@@ -102,15 +110,26 @@ class Transform[ArrayT](ABC):
         """
         pass
 
+    def invert(self) -> Transform | None:
+        """Invert the transformation, returning `None` if not possible."""
+        if self.is_identity():
+            return copy(self)
+        return None
+
     def __invert__(self) -> Transform:
         """Invert transformation if possible.
+
+        Returns `NotImplemented` otherwise (will raise `NotImplementedError`).
 
         Returns
         -------
         Transform
             Inverted transformation.
         """
-        return NotImplemented
+        t = self.invert()
+        if t is None:
+            return NotImplemented
+        return t
 
     def to_device(self, xp, device=None) -> Self:  # noqa: ARG002
         """Return a copy of this transform with array parameters placed on the given device.
@@ -293,7 +312,7 @@ class TransformSequence(Transform[ArrayT], Sequence[Transform[ArrayT]]):
             ),
         )
 
-        self.transforms: list[Transform] = ts
+        self.transforms: list[Transform[ArrayT]] = ts
 
         self.ndim = None
         for t in self.transforms:
@@ -302,7 +321,7 @@ class TransformSequence(Transform[ArrayT], Sequence[Transform[ArrayT]]):
         if self.ndim is not None and len(self.ndim) == 0:
             raise ValueError("Transforms have incompatible dimensionalities")
 
-    def __iter__(self) -> Iterator[Transform]:
+    def __iter__(self) -> Iterator[Transform[ArrayT]]:
         """Iterate through component transforms.
 
         Yields
@@ -320,14 +339,14 @@ class TransformSequence(Transform[ArrayT], Sequence[Transform[ArrayT]]):
         """
         return len(self.transforms)
 
-    def __invert__(self) -> Transform:
+    def invert(self) -> Transform[ArrayT] | None:
         try:
             transforms = [~t for t in reversed(self.transforms)]
         except NotImplementedError:
-            return NotImplemented
+            return None
         return type(self)(
             transforms,
-            spaces=(self.spaces[1], self.spaces[0]),
+            spaces=invert_spaces(self.spaces),
         )
 
     def apply(self, coords: ArrayT) -> ArrayT:
@@ -367,36 +386,56 @@ class TransformSequence(Transform[ArrayT], Sequence[Transform[ArrayT]]):
             return self.transforms[idx]
         return type(self)(self.transforms[idx])
 
-    def to_affine(self, dim=None) -> None:
-        return None
+    def is_identity(self) -> bool:
+        return all(t.is_identity() for t in self)
 
-    def simplify_affine(self, seq_dim: int | None = None):
+    def simplify(self, ndim: int | None = None, drop_inverse: bool = False):
+        """Reduce the number of transformations in this sequence if possible.
 
-        if seq_dim is None:
-            for t in self.transforms:
-                if t.ndim:
-                    seq_dim = next(iter(t.ndim))
-                    break
-        out = []
+        - Compose consecutive transformations which can be expressed as affines
+        - Drop trivial transforms (e.g. identity)
+        - Optionally drop explicit inverse transforms
+          (e.g. replace `Bijection`s with their `forward` transform)
+
+        Also drops all internal space tuples; only the sequence's remains.
+
+        Does not check whether transforms invert each other,
+        e.g. `Translation(1) | Translation(-1)`.
+        """
+        from .transforms.bijection import Bijection
+
+        ndim = to_single_ndim(ndim, self.ndim)
+        out: list[Transform[ArrayT]] = []
         affine = None
         for t in self.transforms:
-            new_affine = t.to_affine(seq_dim)
+            if drop_inverse and isinstance(t, Bijection):
+                t = t.forward
+
+            new_affine = t.to_affine(ndim)
 
             if new_affine is None:
                 if affine is not None:
-                    out.append(affine)
-                affine = None
-                out.append(t)
+                    add_to_output(affine, out)
+                    affine = None
+                add_to_output(t, out)
                 continue
 
             if affine is None:
                 affine = new_affine
-                continue
-            affine = affine @ new_affine  # type: ignore[operator]
+            else:
+                affine = new_affine @ affine  # type: ignore[operator]
 
         if affine is not None:
-            out.append(affine)
+            add_to_output(affine, out)
 
-        self.transforms = out
+        return type(self)(out)
 
-        return self
+
+def add_to_output(transform: Transform, lst: list[Transform]) -> bool:
+    if transform.is_identity():
+        return False
+
+    transform = copy(transform)
+    transform.spaces = (None, None)
+    lst.append(transform)
+    return True

--- a/src/transformnd/graph.py
+++ b/src/transformnd/graph.py
@@ -1,5 +1,6 @@
 """Bridging transforms between known spaces."""
 
+from __future__ import annotations
 from functools import lru_cache
 from collections.abc import Iterable, Iterator
 
@@ -9,7 +10,7 @@ from .base import Transform, TransformSequence
 from .util import SpaceRef, chain_or, dim_intersection, window, ArrayT
 
 
-def split_sequence(seq: TransformSequence) -> Iterator[Transform]:
+def split_sequence(seq: TransformSequence[ArrayT]) -> Iterator[Transform[ArrayT]]:
     """Split a TransformSequence into Transforms with spaces defined.
 
     If a component Transform has its spaces defined,
@@ -105,7 +106,11 @@ class TransformGraph[ArrayT]:
 
     @lru_cache()
     def get_sequence(
-        self, source_space: SpaceRef, target_space: SpaceRef
+        self,
+        source_space: SpaceRef,
+        target_space: SpaceRef,
+        simplify=False,
+        drop_inverse=False,
     ) -> TransformSequence[ArrayT]:
         """Get the shortest TransformSequence for transforming between two spaces.
 
@@ -113,6 +118,12 @@ class TransformGraph[ArrayT]:
         ----------
         source_space : SpaceRef
         target_space : SpaceRef
+        simplify : bool
+            Whether to simplify the transform sequence; see `TransformSequence.simplify`.
+        drop_inverse : bool
+            If `simplify==True`, whether to drop explicit inverses.
+            See `TransformSequence.simplify` for details.
+            Ignored if `simplify==False`.
 
         Returns
         -------
@@ -125,10 +136,13 @@ class TransformGraph[ArrayT]:
             transforms = [
                 self.graph.edges[src, tgt]["transform"] for src, tgt in window(path, 2)
             ]
-        return TransformSequence(
+        seq = TransformSequence(
             transforms,
             spaces=(source_space, target_space),
         )
+        if simplify:
+            seq = seq.simplify(drop_inverse=drop_inverse)
+        return seq
 
     def transform(
         self, source_space: SpaceRef, target_space: SpaceRef, coords: ArrayT
@@ -154,7 +168,7 @@ class TransformGraph[ArrayT]:
 
         Includes inferred reverse transforms.
 
-        N.B. `networkx.Graph.__iter__` iterates through nodes,
+        N.B. the `__iter__` method of some popular graph libraries like networkx iterate through nodes,
         where this effectively iterates through edges.
 
         Yields
@@ -171,9 +185,8 @@ class TransformGraph[ArrayT]:
         for _, _, t in self.graph.edges.data("transform"):
             yield t
 
-    def to_device(self, xp, device=None) -> "TransformGraph[ArrayT]":
+    def to_device(self, xp, device=None) -> TransformGraph[ArrayT]:
         result: TransformGraph[ArrayT] = TransformGraph()
-        result.ndim = self.ndim
         for src, tgt, t in self.graph.edges.data("transform"):
             result.graph.add_edge(src, tgt, transform=t.to_device(xp, device))
         return result

--- a/src/transformnd/transforms/affine.py
+++ b/src/transformnd/transforms/affine.py
@@ -87,6 +87,9 @@ class Affine(Transform[ArrayT]):
         self.matrix = m
         self.ndim = {len(self.matrix) - 1}
 
+    def to_affine(self, dim=None) -> Transform:
+        return self
+
     def apply(self, coords: ArrayT) -> ArrayT:
         coords = self._validate_coords(coords)
         xp = array_namespace(coords)
@@ -440,3 +443,8 @@ class Affine(Transform[ArrayT]):
                 if m[row_idx, col_idx] == 0:
                     m[row_idx, col_idx] = next(it)
         return cls.from_linear_map(m, spaces=spaces)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Affine):
+            return NotImplemented
+        return np.array_equal(self.matrix, other.matrix) and self.spaces == other.spaces

--- a/src/transformnd/transforms/affine.py
+++ b/src/transformnd/transforms/affine.py
@@ -5,7 +5,7 @@ Rigid transformations implemented as affine multiplications.
 from __future__ import annotations
 
 import math
-from typing import Container, Optional, Tuple, Union
+from typing import Container, Union, Self
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -18,7 +18,7 @@ from ..base import Transform, ArrayT
 from ..util import is_square, none_eq, SpaceTuple
 
 
-def arg_as_array(arg, ndim: Optional[int]) -> np.ndarray:
+def arg_as_array(arg, ndim: int | None) -> np.ndarray:
     """Convert a scalar or array-like argument to a 1-D NumPy array.
 
     Parameters
@@ -87,7 +87,7 @@ class Affine(Transform[ArrayT]):
         self.matrix = m
         self.ndim = {len(self.matrix) - 1}
 
-    def to_affine(self, dim=None) -> Transform:
+    def to_affine(self, dim: int | None = None) -> Self:
         return self
 
     def apply(self, coords: ArrayT) -> ArrayT:
@@ -332,7 +332,7 @@ class Affine(Transform[ArrayT]):
     @classmethod
     def rotation3(
         cls,
-        rotation: Union[float, Tuple[float, float, float]],
+        rotation: Union[float, tuple[float, float, float]],
         degrees=True,
         clockwise=False,
         order=(0, 1, 2),
@@ -393,7 +393,7 @@ class Affine(Transform[ArrayT]):
     def shearing(
         cls,
         factor: Union[float, np.ndarray],
-        ndim: Optional[int] = None,
+        ndim: int | None = None,
         *,
         spaces: SpaceTuple = (None, None),
     ) -> Affine[ArrayT]:

--- a/src/transformnd/transforms/affine.py
+++ b/src/transformnd/transforms/affine.py
@@ -4,7 +4,6 @@ Rigid transformations implemented as affine multiplications.
 
 from __future__ import annotations
 
-from functools import lru_cache
 import math
 from typing import Container, Union, Self
 
@@ -16,7 +15,7 @@ from copy import copy
 from array_api_compat import array_namespace
 from array_api_compat import device as xp_device
 from ..base import Transform, ArrayT
-from ..util import is_square, none_eq, SpaceTuple
+from ..util import is_square, none_eq, SpaceTuple, to_single_ndim
 
 
 def arg_as_array(arg, ndim: int | None) -> np.ndarray:
@@ -88,10 +87,11 @@ class Affine(Transform[ArrayT]):
         self.matrix = m
         self.ndim = {len(self.matrix) - 1}
 
-    def to_affine(self, dim: int | None = None) -> Self:
+    def to_affine(self, ndim: int | None = None) -> Self | None:
+        # check that if ndim is given, it matches expectation
+        to_single_ndim(ndim, self.ndim)
         return self
 
-    @lru_cache()
     def cast_matrix(self, namespace, device) -> ArrayT:
         return namespace.asarray(self.matrix, device=device)
 
@@ -104,17 +104,24 @@ class Affine(Transform[ArrayT]):
             [coords, xp.ones((coords.shape[0], 1), dtype=coords.dtype)],  # type: ignore[attr-defined]
             axis=1,
         )
-        out: ArrayT = (m @ coords.T).T[:, :-1]  # type: ignore[attr-defined]
+        out: ArrayT = coords.dot(m.T)[:, :-1]  # type: ignore[attr-defined]
         return out
 
-    def __invert__(self) -> Transform:
+    def invert(self) -> Self | None:
+        try:
+            inv = np.linalg.inv(self.matrix)
+        except np.linalg.LinAlgError:
+            return None
+
         return type(self)(
-            np.linalg.inv(self.matrix),
+            inv,
             spaces=(self.spaces[1], self.spaces[0]),
         )
 
     def __matmul__(self, rhs: Affine[ArrayT]) -> Affine[ArrayT]:
         """Compose two affine transforms by matrix multiplication.
+
+        As with affine matrices the right hand operand is effectively applied first.
 
         Parameters
         ----------
@@ -220,7 +227,7 @@ class Affine(Transform[ArrayT]):
     def translation(
         cls,
         translation: ArrayLike,
-        ndim: Optional[int] = None,
+        ndim: int | None = None,
         *,
         spaces: SpaceTuple = (None, None),
     ) -> Affine[ArrayT]:
@@ -248,7 +255,7 @@ class Affine(Transform[ArrayT]):
     def scaling(
         cls,
         scale: ArrayLike,
-        ndim: Optional[int] = None,
+        ndim: int | None = None,
         *,
         spaces: SpaceTuple = (None, None),
     ) -> Affine[ArrayT]:
@@ -452,3 +459,14 @@ class Affine(Transform[ArrayT]):
         if not isinstance(other, Affine):
             return NotImplemented
         return np.array_equal(self.matrix, other.matrix) and self.spaces == other.spaces
+
+    def into_affine(self, ndim: int | None = None) -> Affine[ArrayT]:
+        ndim = to_single_ndim(ndim, self.ndim)
+        return self
+
+    def is_identity(self) -> bool:
+        xp = array_namespace(self.matrix)
+        assert self.ndim is not None
+        ndim = list(self.ndim).pop()
+        identity = xp.eye(ndim + 1, dtype=self.matrix.dtype, device=self.matrix.device)
+        return xp.all(xp.equal(self.matrix, identity))

--- a/src/transformnd/transforms/affine.py
+++ b/src/transformnd/transforms/affine.py
@@ -104,7 +104,7 @@ class Affine(Transform[ArrayT]):
             [coords, xp.ones((coords.shape[0], 1), dtype=coords.dtype)],  # type: ignore[attr-defined]
             axis=1,
         )
-        out: ArrayT = coords.dot(m.T)[:, :-1]  # type: ignore[attr-defined]
+        out: ArrayT = (coords @ m.T)[:, :-1]  # type: ignore[attr-defined]
         return out
 
     def invert(self) -> Self | None:

--- a/src/transformnd/transforms/bijection.py
+++ b/src/transformnd/transforms/bijection.py
@@ -1,3 +1,7 @@
+from typing import Self
+
+from transformnd.transforms.affine import Affine
+
 from ..base import Transform, ArrayT
 from ..util import SpaceTuple, dim_intersection, invert_spaces
 
@@ -37,8 +41,15 @@ class Bijection(Transform[ArrayT]):
     def apply(self, coords: ArrayT) -> ArrayT:
         return self.forward.apply(coords)
 
-    def __invert__(self) -> Transform[ArrayT]:
+    def invert(self) -> Self | None:
         return type(self)(self.inverse, self.forward, spaces=invert_spaces(self.spaces))
 
-    def to_affine(self, dim=None) -> None:
-        return None
+    def is_identity(self) -> bool:
+        return self.forward.is_identity() and self.inverse.is_identity()
+
+    def to_affine(self, ndim: int | None = None) -> Affine[ArrayT] | None:
+        fwd = self.forward.to_affine(ndim)
+        inv = self.inverse.to_affine(ndim)
+        if fwd is None or inv is None:
+            return None
+        return type(self)(fwd, inv)  # type:ignore

--- a/src/transformnd/transforms/bijection.py
+++ b/src/transformnd/transforms/bijection.py
@@ -1,5 +1,7 @@
 from typing import Self
 
+from array_api_compat import array_namespace
+
 from transformnd.transforms.affine import Affine
 
 from ..base import Transform, ArrayT
@@ -49,7 +51,18 @@ class Bijection(Transform[ArrayT]):
 
     def to_affine(self, ndim: int | None = None) -> Affine[ArrayT] | None:
         fwd = self.forward.to_affine(ndim)
-        inv = self.inverse.to_affine(ndim)
-        if fwd is None or inv is None:
+        if fwd is None:
             return None
-        return type(self)(fwd, inv)  # type:ignore
+        inv = self.inverse.to_affine(ndim)
+        if inv is None:
+            return None
+
+        inv_inv = inv.invert()
+        if inv_inv is None:
+            return None
+
+        xp = array_namespace(fwd.matrix)
+        if xp.equal(fwd.matrix, inv_inv.matrix):
+            return fwd
+
+        return None

--- a/src/transformnd/transforms/bijection.py
+++ b/src/transformnd/transforms/bijection.py
@@ -39,3 +39,6 @@ class Bijection(Transform[ArrayT]):
 
     def __invert__(self) -> Transform[ArrayT]:
         return type(self)(self.inverse, self.forward, spaces=invert_spaces(self.spaces))
+
+    def to_affine(self, dim=None) -> None:
+        return None

--- a/src/transformnd/transforms/by_dimension.py
+++ b/src/transformnd/transforms/by_dimension.py
@@ -128,6 +128,3 @@ class ByDimension(Transform[ArrayT]):
             subtransforms=inverted_transforms,
             spaces=(self.spaces[1], self.spaces[0]),
         )
-
-    def to_affine(self, dim=None) -> None:
-        return None

--- a/src/transformnd/transforms/by_dimension.py
+++ b/src/transformnd/transforms/by_dimension.py
@@ -128,3 +128,6 @@ class ByDimension(Transform[ArrayT]):
             subtransforms=inverted_transforms,
             spaces=(self.spaces[1], self.spaces[0]),
         )
+
+    def to_affine(self, dim=None) -> None:
+        return None

--- a/src/transformnd/transforms/by_dimension.py
+++ b/src/transformnd/transforms/by_dimension.py
@@ -3,7 +3,7 @@ from array_api_compat import array_namespace
 from .simple import Identity
 
 from ..base import Transform
-from ..util import SpaceTuple, ArrayT, check_ndim
+from ..util import SpaceTuple, ArrayT, check_ndim, invert_spaces
 
 
 class SubTransform[ArrayT]:
@@ -108,23 +108,26 @@ class ByDimension(Transform[ArrayT]):
                 output[:, o] = transformed[:, idx]  # type: ignore
         return output
 
-    def __invert__(self) -> Transform[ArrayT]:
-        """Invert transformation if possible.
+    def invert(self) -> Transform[ArrayT] | None:
+        try:
+            inverted_transforms = [
+                SubTransform[ArrayT](
+                    input_axes=t.output_axes,
+                    output_axes=t.input_axes,
+                    transform=~t.transform,
+                )
+                for t in reversed(self.subtransforms)
+            ]
+        except NotImplementedError:
+            return None
 
-        Returns
-        -------
-        Transform
-            Inverted transformation.
-        """
-        inverted_transforms = [
-            SubTransform[ArrayT](
-                input_axes=t.output_axes,
-                output_axes=t.input_axes,
-                transform=~t.transform,
-            )
-            for t in reversed(self.subtransforms)
-        ]
         return type(self)(
             subtransforms=inverted_transforms,
-            spaces=(self.spaces[1], self.spaces[0]),
+            spaces=invert_spaces(self.spaces),
         )
+
+    def is_identity(self) -> bool:
+        for t in self.subtransforms:
+            if t.input_axes != t.output_axes or not t.transform.is_identity():
+                return False
+        return True

--- a/src/transformnd/transforms/map_axis.py
+++ b/src/transformnd/transforms/map_axis.py
@@ -1,8 +1,9 @@
+from typing import Self
 from array_api_compat import array_namespace
 import numpy as np
 
 from ..base import Transform
-from ..util import ArrayT, SpaceTuple
+from ..util import ArrayT, SpaceTuple, to_single_ndim
 from ..transforms.affine import Affine
 
 
@@ -28,19 +29,23 @@ class MapAxis(Transform[ArrayT]):
         spaces : tuple[SpaceRef, SpaceRef]
             Optional source and target spaces
         """
+        s_perm = sorted(permutation)
+        if any(a != b for a, b in enumerate(s_perm)):
+            raise ValueError(
+                "N-D permutation must contain all dimensions [0, N) exactly once"
+            )
         self.permutation = permutation
         self.ndim = {len(permutation)}
         self.spaces = spaces
 
-    def to_affine(self, dim: int | None = None) -> Affine:
+    def is_identity(self) -> bool:
+        return all(a == b for a, b in enumerate(self.permutation))
 
-        if dim is None:
-            assert self.ndim is not None
-            dim = next(iter(self.ndim))
-        if len(self.permutation) != dim:
-            raise ValueError("Permutation vector does not match dimensions.")
-        m = np.eye(dim + 1)
-        m[:-1, :-1] = np.eye(dim)[self.permutation]
+    def to_affine(self, ndim: int | None = None) -> Affine[ArrayT] | None:
+        ndim = to_single_ndim(ndim, self.ndim)
+        m = np.eye(ndim + 1)
+        perm = self.permutation + [ndim]
+        m = m[perm, :]
         return Affine(m, spaces=self.spaces)
 
     def apply(self, coords: ArrayT) -> ArrayT:
@@ -55,14 +60,7 @@ class MapAxis(Transform[ArrayT]):
         xp = array_namespace(coords)
         return xp.take(coords, self.permutation, 1)
 
-    def __invert__(self) -> Transform[ArrayT]:
-        """Invert transformation if possible.
-
-        Returns
-        -------
-        Transform[ArrayT]
-            Inverted transformation.
-        """
+    def invert(self) -> Self | None:
         return type(self)(
             list(np.argsort(self.permutation)),
             spaces=(self.spaces[1], self.spaces[0]),

--- a/src/transformnd/transforms/map_axis.py
+++ b/src/transformnd/transforms/map_axis.py
@@ -3,6 +3,7 @@ import numpy as np
 
 from ..base import Transform
 from ..util import ArrayT, SpaceTuple
+from ..transforms.affine import Affine
 
 
 class MapAxis(Transform[ArrayT]):
@@ -30,6 +31,17 @@ class MapAxis(Transform[ArrayT]):
         self.permutation = permutation
         self.ndim = {len(permutation)}
         self.spaces = spaces
+
+    def to_affine(self, dim: int | None = None) -> Affine:
+
+        if dim is None:
+            assert self.ndim is not None
+            dim = next(iter(self.ndim))
+        if len(self.permutation) != dim:
+            raise ValueError("Permutation vector does not match dimensions.")
+        m = np.eye(dim + 1)
+        m[:-1, :-1] = np.eye(dim)[self.permutation]
+        return Affine(m, spaces=self.spaces)
 
     def apply(self, coords: ArrayT) -> ArrayT:
         """Apply transformation to coordinates.

--- a/src/transformnd/transforms/moving_least_squares.py
+++ b/src/transformnd/transforms/moving_least_squares.py
@@ -4,7 +4,9 @@ Implementation of Moving Least Squares transformation.
 Requires the `movingleastsquares` extra.
 """
 
+from array_api_compat import array_namespace
 import numpy as np
+from typing import Self
 from molesq.transform import Transformer as _Transformer
 
 from ..base import SpaceTuple, Transform
@@ -47,7 +49,16 @@ class MovingLeastSquares(Transform[np.ndarray]):
         coords = self._validate_coords(coords)
         return self._transformer.transform(coords)
 
-    def __invert__(self) -> Transform:
+    def is_identity(self) -> bool:
+        xp = array_namespace(self._transformer.control_points)
+        return xp.all(
+            xp.equal(
+                self._transformer.control_points,
+                self._transformer.deformed_control_points,
+            )
+        )
+
+    def invert(self) -> Self | None:
         return type(self)(
             self._transformer.deformed_control_points,
             self._transformer.control_points,

--- a/src/transformnd/transforms/moving_least_squares.py
+++ b/src/transformnd/transforms/moving_least_squares.py
@@ -53,3 +53,6 @@ class MovingLeastSquares(Transform[np.ndarray]):
             self._transformer.control_points,
             spaces=invert_spaces(self.spaces),
         )
+
+    def to_affine(self, dim=None) -> None:
+        return None

--- a/src/transformnd/transforms/moving_least_squares.py
+++ b/src/transformnd/transforms/moving_least_squares.py
@@ -53,6 +53,3 @@ class MovingLeastSquares(Transform[np.ndarray]):
             self._transformer.control_points,
             spaces=invert_spaces(self.spaces),
         )
-
-    def to_affine(self, dim=None) -> None:
-        return None

--- a/src/transformnd/transforms/reflection.py
+++ b/src/transformnd/transforms/reflection.py
@@ -204,3 +204,6 @@ class Reflect(Transform[np.ndarray]):
 
     def __invert__(self):
         return copy(self)
+
+    def to_affine(self, dim=None) -> None:
+        return None

--- a/src/transformnd/transforms/reflection.py
+++ b/src/transformnd/transforms/reflection.py
@@ -204,6 +204,3 @@ class Reflect(Transform[np.ndarray]):
 
     def __invert__(self):
         return copy(self)
-
-    def to_affine(self, dim=None) -> None:
-        return None

--- a/src/transformnd/transforms/reflection.py
+++ b/src/transformnd/transforms/reflection.py
@@ -1,5 +1,6 @@
 from collections.abc import Sequence
 from copy import copy
+from typing import Self
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -202,5 +203,5 @@ class Reflect(Transform[np.ndarray]):
 
         return cls(normals, origin, spaces=spaces)
 
-    def __invert__(self):
+    def invert(self) -> Self | None:
         return copy(self)

--- a/src/transformnd/transforms/simple.py
+++ b/src/transformnd/transforms/simple.py
@@ -3,7 +3,7 @@ Simple transformations like rigid translation and scaling.
 """
 
 from copy import copy
-from typing import Self
+from typing import Self, Optional
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -12,6 +12,7 @@ from array_api_compat import array_namespace
 from array_api_compat import device as xp_device
 from ..base import Transform
 from ..util import ArrayT, chain_or, SpaceTuple, invert_spaces
+from ..transforms.affine import Affine
 
 
 class Identity(Transform[ArrayT]):
@@ -43,6 +44,13 @@ class Identity(Transform[ArrayT]):
 
     def __invert__(self) -> Transform[ArrayT]:
         return self
+
+    def to_affine(self, dim: int | None = None) -> Optional[Transform]:
+        if dim is None:
+            assert self.ndim is not None
+            dim = next(iter(self.ndim))
+        m = np.eye(dim + 1)
+        return Affine(m, spaces=self.spaces)
 
     def apply(self, coords: ArrayT) -> ArrayT:
         xp = array_namespace(coords)
@@ -80,6 +88,18 @@ class Translate(Transform[ArrayT]):
         if self.translation.shape not in [(), (1,)]:
             self.ndim = {self.translation.shape[0]}
         # otherwise, can be broadcast to anything
+
+    def to_affine(self, dim: int | None = None) -> Optional[Transform]:
+
+        if dim is None:
+            assert self.ndim is not None
+            dim = next(iter(self.ndim))
+        m = np.eye(dim + 1)
+        if self.translation.size == 1:
+            m[:-1, -1] = self.translation.item()
+        else:
+            m[:-1, -1] = self.translation.reshape(dim)
+        return Affine(m, spaces=self.spaces)
 
     def apply(self, coords: ArrayT) -> ArrayT:
         coords = self._validate_coords(coords)
@@ -129,6 +149,25 @@ class Scale(Transform[ArrayT]):
         if self.scale.shape not in [(), (1,)]:
             self.ndim = {self.scale.shape[0]}
         # otherwise, can be broadcast to anything
+
+    def to_affine(self, dim: int | None = None) -> Optional[Transform]:
+
+        if dim is None:
+            if not self.ndim:
+                return None
+            else:
+                assert self.ndim is not None
+                dim = next(iter(self.ndim))
+
+        if self.scale.size == 1:
+            scale_vec = np.full(dim, self.scale.item())
+        else:
+            scale_vec = self.scale
+            if len(scale_vec) != dim:
+                raise ValueError("Scale vector does not match dimensions.")
+        m = np.eye(dim + 1)
+        m[:-1, :-1] = np.diag(scale_vec)
+        return Affine(m, spaces=self.spaces)
 
     def apply(self, coords: ArrayT) -> ArrayT:
         coords = self._validate_coords(coords)

--- a/src/transformnd/transforms/simple.py
+++ b/src/transformnd/transforms/simple.py
@@ -3,7 +3,7 @@ Simple transformations like rigid translation and scaling.
 """
 
 from copy import copy
-from typing import Self, Optional
+from typing import Self
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -11,7 +11,7 @@ from numpy.typing import ArrayLike
 from array_api_compat import array_namespace
 from array_api_compat import device as xp_device
 from ..base import Transform
-from ..util import ArrayT, chain_or, SpaceTuple, invert_spaces
+from ..util import ArrayT, chain_or, SpaceTuple, invert_spaces, to_single_ndim
 from ..transforms.affine import Affine
 
 
@@ -45,11 +45,9 @@ class Identity(Transform[ArrayT]):
     def __invert__(self) -> Transform[ArrayT]:
         return self
 
-    def to_affine(self, dim: int | None = None) -> Optional[Transform]:
-        if dim is None:
-            assert self.ndim is not None
-            dim = next(iter(self.ndim))
-        m = np.eye(dim + 1)
+    def to_affine(self, ndim: int | None = None) -> Affine[ArrayT] | None:
+        ndim = to_single_ndim(ndim, self.ndim)
+        m = np.eye(ndim + 1)
         return Affine(m, spaces=self.spaces)
 
     def apply(self, coords: ArrayT) -> ArrayT:
@@ -89,16 +87,11 @@ class Translate(Transform[ArrayT]):
             self.ndim = {self.translation.shape[0]}
         # otherwise, can be broadcast to anything
 
-    def to_affine(self, dim: int | None = None) -> Optional[Transform]:
+    def to_affine(self, ndim: int | None = None) -> Affine[ArrayT] | None:
+        ndim = to_single_ndim(ndim, self.ndim)
 
-        if dim is None:
-            assert self.ndim is not None
-            dim = next(iter(self.ndim))
-        m = np.eye(dim + 1)
-        if self.translation.size == 1:
-            m[:-1, -1] = self.translation.item()
-        else:
-            m[:-1, -1] = self.translation.reshape(dim)
+        m = np.eye(ndim + 1)
+        m[:-1, -1] = self.translation
         return Affine(m, spaces=self.spaces)
 
     def apply(self, coords: ArrayT) -> ArrayT:
@@ -150,22 +143,14 @@ class Scale(Transform[ArrayT]):
             self.ndim = {self.scale.shape[0]}
         # otherwise, can be broadcast to anything
 
-    def to_affine(self, dim: int | None = None) -> Optional[Transform]:
+    def to_affine(self, ndim: int | None = None) -> Affine[ArrayT] | None:
+        ndim = to_single_ndim(ndim, self.ndim)
 
-        if dim is None:
-            if not self.ndim:
-                return None
-            else:
-                assert self.ndim is not None
-                dim = next(iter(self.ndim))
-
-        if self.scale.size == 1:
-            scale_vec = np.full(dim, self.scale.item())
+        if np.ndim(self.scale) == 0:
+            scale_vec = np.full(ndim, self.scale)
         else:
             scale_vec = self.scale
-            if len(scale_vec) != dim:
-                raise ValueError("Scale vector does not match dimensions.")
-        m = np.eye(dim + 1)
+        m = np.eye(ndim + 1)
         m[:-1, :-1] = np.diag(scale_vec)
         return Affine(m, spaces=self.spaces)
 
@@ -175,7 +160,7 @@ class Scale(Transform[ArrayT]):
         d = xp_device(coords)
         return coords * xp.asarray(self.scale, device=d)
 
-    def __invert__(self) -> Transform:
+    def invert(self) -> Self | None:
         return type(self)(
             1 / self.scale,
             spaces=invert_spaces(self.spaces),

--- a/src/transformnd/transforms/thinplate.py
+++ b/src/transformnd/transforms/thinplate.py
@@ -78,7 +78,7 @@ class ThinPlateSplines(Transform[np.ndarray]):
             self.target_control_points,
         )
 
-    def __invert__(self) -> Transform[np.ndarray]:
+    def invert(self) -> Transform[np.ndarray] | None:
         return type(self)(
             self.target_control_points,
             self.source_control_points,

--- a/src/transformnd/transforms/thinplate.py
+++ b/src/transformnd/transforms/thinplate.py
@@ -91,6 +91,3 @@ class ThinPlateSplines(Transform[np.ndarray]):
         P = mops.P_matrix(coords)
         # The warped pts are the affine part + the non-uniform part
         return P @ self.A + U @ self.W
-
-    def to_affine(self, dim=None) -> None:
-        return None

--- a/src/transformnd/transforms/thinplate.py
+++ b/src/transformnd/transforms/thinplate.py
@@ -91,3 +91,6 @@ class ThinPlateSplines(Transform[np.ndarray]):
         P = mops.P_matrix(coords)
         # The warped pts are the affine part + the non-uniform part
         return P @ self.A + U @ self.W
+
+    def to_affine(self, dim=None) -> None:
+        return None

--- a/src/transformnd/util.py
+++ b/src/transformnd/util.py
@@ -111,7 +111,7 @@ def same_or_none(*args: Any, default=NO_DEFAULT) -> Any:
     return prev
 
 
-def window(iterable: Iterable, length: int) -> Iterator[tuple[Any, ...]]:
+def window[T](iterable: Iterable[T], length: int) -> Iterator[tuple[T, ...]]:
     """Sliding window over iterable.
 
     e.g. `(it[0], it[1]), (it[1], it[2]), (it[2], it[3]), ...`
@@ -190,21 +190,33 @@ def space_str(space: SpaceRef | None) -> str:
 
 
 def is_square(arr: ArrayT) -> bool:
+    """Check whether an array is 2D and has the same number of rows as columns"""
     xp = array_namespace(arr)
     ndim, shape = xp.ndim(arr), xp.shape(arr)
     return ndim == 2 and shape[0] == shape[1]
 
 
-def dim_intersection(dims1: set[int] | None, dims2: set[int] | None) -> set[int] | None:
+def dim_intersection(
+    dims1: set[int] | None, dims2: set[int] | None, error_on_empty: bool = False
+) -> set[int] | None:
+    """Find the intersection between two sets of constraints.
+
+    None means no constraints.
+    If `error_on_empty` is truthy and there is no intersection, raise an error.
+    """
     if dims1 is None:
-        return dims2
+        out = dims2
     elif dims2 is None:
-        return dims1
+        out = dims1
     else:
-        return dims1.intersection(dims2)
+        out = dims1.intersection(dims2)
+    if error_on_empty and out is not None and len(out) == 0:
+        raise ValueError(f"incompatible dimensions: {dims1} ∩ {dims2}")
+    return out
 
 
 def invert_spaces(spaces: SpaceTuple) -> SpaceTuple:
+    """Invert the given (source, target) space tuple."""
     return (spaces[1], spaces[0])
 
 
@@ -214,3 +226,26 @@ def are_coords(coords: ArrayT, ndim: set[int] | None = None):
         raise ValueError("Coords must be a 2D array")
     check_ndim(xp.shape(coords)[1], ndim)
     return coords
+
+
+def to_single_ndim(ndim: None | int = None, ndims: None | set[int] = None) -> int:
+    """Select a single ndim from the given options.
+
+    Error if a single dimension cannot be selected;
+    i.e. both are None or there is a conflict.
+
+    Useful when converting a transformation with multi-dimensionality support
+    (e.g. a scalar translation) into one with single-dimensionality support
+    (e.g. an affine).
+    """
+    if ndim is None:
+        if ndims is None:
+            raise ValueError("no ndims specified")
+        if len(ndims) != 1:
+            raise ValueError(f"needs exactly one ndim, got {ndims}")
+        return list(ndims).pop()
+
+    if ndims is None or ndim in ndims:
+        return ndim
+
+    raise ValueError(f"dimensionality conflict: {ndim} not in {ndims}")

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,0 +1,36 @@
+from transformnd.base import Transform
+from transformnd.util import SpaceTuple, to_single_ndim
+from transformnd.transforms.affine import Affine
+from copy import copy
+import numpy as np
+
+
+class NullTransform(Transform):
+    """Flexible identity-like transform used for testing."""
+
+    def __init__(
+        self,
+        ndim: set[int] | None = None,
+        invertible: bool = False,
+        affineable: bool = False,
+        *,
+        spaces: SpaceTuple = (None, None),
+    ):
+        super().__init__(spaces=spaces)
+        self.ndim = ndim
+        self.invertible = invertible
+        self.affineable = affineable
+
+    def invert(self) -> Transform | None:
+        if self.invertible:
+            return copy(self)
+        return None
+
+    def to_affine(self, ndim: int | None = None) -> Affine | None:
+        ndim = to_single_ndim(ndim, self.ndim)
+        if self.affineable:
+            return Affine.identity(ndim, spaces=self.spaces)
+        return None
+
+    def apply(self, coords: np.ndarray) -> np.ndarray:
+        return coords.copy()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,10 +9,10 @@ def make_coords(shape):
 
 
 @pytest.fixture
-def coords5x3():
+def coords5x3() -> np.ndarray:
     return make_coords((5, 3))
 
 
 @pytest.fixture
-def rng():
+def rng() -> np.random.RandomState:
     return np.random.RandomState(SEED)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -5,9 +5,10 @@ import pytest
 
 from transformnd.base import TransformSequence, TransformWrapper
 from transformnd.transforms.simple import Translate, Scale
-from transformnd.transforms.moving_least_squares import MovingLeastSquares
 from transformnd.transforms.affine import Affine
 from transformnd.util import window
+
+from .common import NullTransform
 
 
 def noop(arg):
@@ -83,39 +84,45 @@ def test_maths():
     assert np.allclose((~t1).apply(t1.apply(coords)), coords)
 
 
-def test_simplify_affine1():
-    dim = 3
-    s1 = Scale([5, 5, 5])
-    s2 = Translate([2, 3, 4])
-    s3 = MovingLeastSquares(np.array([[0, 0, 0]]), np.array([[1, 1, 1]]))
+def test_simplify_affine1(rng):
+    s1 = Scale(np.array([5, 5, 5], float))
+    s2 = Translate(np.array([2, 3, 4], float))
+    s3 = NullTransform()
     s4 = Scale(6)
+    coords = rng.random((10, 3))
     sequence = TransformSequence([s1, s2, s3, s4])
-    sequence_simplified = sequence.simplify_affine().transforms
-    s1_affine = s1.to_affine()
-    s2_affine = s2.to_affine()
-    s4_affine = s4.to_affine(dim)
-    assert isinstance(s1_affine, Affine)
-    assert isinstance(s2_affine, Affine)
-    assert isinstance(s4_affine, Affine)
-    merged_affine = s1_affine @ s2_affine
-    sequence_expected = [merged_affine, s3, s4_affine]
-    assert sequence_simplified == sequence_expected
+    expected = sequence.apply(coords)
+    simplified = sequence.simplify()
+    applied = simplified.apply(coords)
+    assert expected == pytest.approx(applied)
+    assert len(simplified) == 3
+    assert isinstance(simplified[0], Affine)
+    assert not isinstance(simplified[1], Affine)
+    assert isinstance(simplified[2], Affine)
 
 
-def test_simplify_affine2():
+def test_simplify_affine2(rng):
+    coords = rng.random((10, 3))
     dim = 3
-    s3 = MovingLeastSquares(np.array([[0, 0, 0]]), np.array([[1, 1, 1]]))
-    s1 = Scale([5, 5, 5])
-    s2 = Translate([2, 3, 4])
+    s1 = NullTransform()
+    s2 = Scale(np.array([5, 5, 5], float))
+    s3 = Translate(np.array([2, 3, 4], float))
     s4 = Scale(6)
-    s1_affine = s1.to_affine()
     s2_affine = s2.to_affine()
+    s3_affine = s3.to_affine()
     s4_affine = s4.to_affine(dim)
-    assert isinstance(s1_affine, Affine)
-    assert isinstance(s2_affine, Affine)
-    assert isinstance(s4_affine, Affine)
-    sequence = TransformSequence([s3, s1, s2, s4])
-    sequence_simplified = sequence.simplify_affine().transforms
-    merged_affine = s1_affine @ s2_affine @ s4_affine
-    sequence_expected = [s3, merged_affine]
-    assert sequence_simplified == sequence_expected
+    assert s2_affine is not None
+    assert s3_affine is not None
+    assert s4_affine is not None
+    seq = TransformSequence([s1, s2, s3, s4])
+    coords2 = seq.apply(coords)
+    simplified = seq.simplify()
+    assert len(simplified) == 2
+    assert isinstance(simplified[0], NullTransform)
+    internal_affine = simplified[1]
+    assert isinstance(internal_affine, Affine)
+    coords3 = simplified.apply(coords)
+    assert coords2 == pytest.approx(coords3)
+
+    merged_affine = s4_affine @ s3_affine @ s2_affine
+    assert merged_affine.matrix == pytest.approx(internal_affine.matrix)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -4,7 +4,9 @@ import numpy as np
 import pytest
 
 from transformnd.base import TransformSequence, TransformWrapper
-from transformnd.transforms.simple import Translate
+from transformnd.transforms.simple import Translate, Scale
+from transformnd.transforms.moving_least_squares import MovingLeastSquares
+from transformnd.transforms.affine import Affine
 from transformnd.util import window
 
 
@@ -79,3 +81,41 @@ def test_maths():
 
     assert np.allclose((t1 | ~t1).apply(coords), coords)
     assert np.allclose((~t1).apply(t1.apply(coords)), coords)
+
+
+def test_simplify_affine1():
+    dim = 3
+    s1 = Scale([5, 5, 5])
+    s2 = Translate([2, 3, 4])
+    s3 = MovingLeastSquares(np.array([[0, 0, 0]]), np.array([[1, 1, 1]]))
+    s4 = Scale(6)
+    sequence = TransformSequence([s1, s2, s3, s4])
+    sequence_simplified = sequence.simplify_affine().transforms
+    s1_affine = s1.to_affine()
+    s2_affine = s2.to_affine()
+    s4_affine = s4.to_affine(dim)
+    assert isinstance(s1_affine, Affine)
+    assert isinstance(s2_affine, Affine)
+    assert isinstance(s4_affine, Affine)
+    merged_affine = s1_affine @ s2_affine
+    sequence_expected = [merged_affine, s3, s4_affine]
+    assert sequence_simplified == sequence_expected
+
+
+def test_simplify_affine2():
+    dim = 3
+    s3 = MovingLeastSquares(np.array([[0, 0, 0]]), np.array([[1, 1, 1]]))
+    s1 = Scale([5, 5, 5])
+    s2 = Translate([2, 3, 4])
+    s4 = Scale(6)
+    s1_affine = s1.to_affine()
+    s2_affine = s2.to_affine()
+    s4_affine = s4.to_affine(dim)
+    assert isinstance(s1_affine, Affine)
+    assert isinstance(s2_affine, Affine)
+    assert isinstance(s4_affine, Affine)
+    sequence = TransformSequence([s3, s1, s2, s4])
+    sequence_simplified = sequence.simplify_affine().transforms
+    merged_affine = s1_affine @ s2_affine @ s4_affine
+    sequence_expected = [s3, merged_affine]
+    assert sequence_simplified == sequence_expected

--- a/tests/transforms/test_affine.py
+++ b/tests/transforms/test_affine.py
@@ -1,18 +1,20 @@
 import numpy as np
 import pytest
 
+from transformnd.base import TransformSequence
 from transformnd.transforms.affine import Affine
+from transformnd.transforms.simple import Scale, Translate
 
 
 def test_identity():
     i2 = Affine[np.ndarray].identity(2)
-    test = np.array([(1, 1), (2, 3), (-2, 50)])
+    test = np.array([(1, 1), (2, 3), (-2, 50)], float)
     ref = test.copy()
     assert np.allclose(i2.apply(test), ref)
     assert np.allclose((~i2).apply(test), ref)
 
 
-@pytest.mark.parametrize(["ndim"], [[d] for d in range(2, 6)])
+@pytest.mark.parametrize(["ndim"], [[d] for d in range(1, 6)])
 def test_translation(ndim, rng):
     t = 1
 
@@ -50,6 +52,89 @@ def test_rotation2():
     for exp in reversed(expected[:-1]):
         coords = inv.apply(coords)
         assert np.allclose(coords[0], exp)
+
+
+def test_matmul(subtests):
+    # scale factors for 2D on the first diagonal;
+    # bottom right must be 1, otherwise bottom row must be 0
+    scale = np.array([[2, 0, 0], [0, 3, 0], [0, 0, 1]], float)
+    # 3rd column is all 1s to fit the affine matrix
+    coords = np.array([[1, 2, 1], [3, 4, 1]], float)
+    s_result = coords.dot(scale.T)
+    s_expected = np.array(
+        [
+            [2, 6, 1],
+            [6, 12, 1],
+        ],
+        float,
+    )
+    with subtests.test(msg="scale results"):
+        assert s_result == pytest.approx(s_expected)
+
+    translation = np.array([[1, 0, 10], [0, 1, 20], [0, 0, 1]], float)
+    t_result = coords.dot(translation.T)
+    t_expected = np.array(
+        [
+            [11, 22, 1],
+            [13, 24, 1],
+        ],
+        float,
+    )
+    with subtests.test(msg="translation results"):
+        assert t_result == pytest.approx(t_expected)
+
+    scale_translate = translation @ scale
+    expected_scale_translation = np.array(
+        [
+            [2, 0, 10],
+            [0, 3, 20],
+            [0, 0, 1],
+        ],
+        float,
+    )
+    with subtests.test(msg="scale->translate matrix"):
+        assert scale_translate == pytest.approx(expected_scale_translation)
+
+    with subtests.test(msg="scale->translate results"):
+        expected = coords.dot(scale.T).dot(translation.T)
+        assert coords.dot(scale_translate.T) == pytest.approx(expected)
+
+    translation_scale = scale @ translation
+    with subtests.test(msg="translate->scale results"):
+        expected = coords.dot(translation.T).dot(scale.T)
+        assert coords.dot(translation_scale.T) == pytest.approx(expected)
+
+
+def test_affine_combination(rng):
+    scale = Affine.scaling([1.5, 2.5])
+    translate = Affine.translation([11.5, 22.5])
+
+    inputs = rng.random((5, 2))
+
+    st_seq = TransformSequence([scale, translate])
+    st = translate @ scale
+    assert st.apply(inputs) == pytest.approx(st_seq.apply(inputs))
+
+    ts_seq = TransformSequence([translate, scale])
+    ts = scale @ translate
+    assert ts.apply(inputs) == pytest.approx(ts_seq.apply(inputs))
+
+
+def test_inversion(rng):
+    scale = Scale([1.5, 2.5])
+    translate = Translate([11.5, 22.5])
+
+    scale_aff = scale.to_affine()
+    assert scale_aff is not None
+    translate_aff = translate.to_affine()
+    assert translate_aff is not None
+
+    aff = translate_aff @ scale_aff
+    inv_aff = ~aff
+
+    coords = rng.random((5, 2))
+
+    assert inv_aff.apply(aff.apply(coords)) == pytest.approx(coords)
 
 
 # def test_reflection():

--- a/tests/transforms/test_affine.py
+++ b/tests/transforms/test_affine.py
@@ -60,7 +60,7 @@ def test_matmul(subtests):
     scale = np.array([[2, 0, 0], [0, 3, 0], [0, 0, 1]], float)
     # 3rd column is all 1s to fit the affine matrix
     coords = np.array([[1, 2, 1], [3, 4, 1]], float)
-    s_result = coords.dot(scale.T)
+    s_result = coords @ scale.T
     s_expected = np.array(
         [
             [2, 6, 1],
@@ -72,7 +72,7 @@ def test_matmul(subtests):
         assert s_result == pytest.approx(s_expected)
 
     translation = np.array([[1, 0, 10], [0, 1, 20], [0, 0, 1]], float)
-    t_result = coords.dot(translation.T)
+    t_result = coords @ translation.T
     t_expected = np.array(
         [
             [11, 22, 1],
@@ -96,13 +96,13 @@ def test_matmul(subtests):
         assert scale_translate == pytest.approx(expected_scale_translation)
 
     with subtests.test(msg="scale->translate results"):
-        expected = coords.dot(scale.T).dot(translation.T)
-        assert coords.dot(scale_translate.T) == pytest.approx(expected)
+        expected = (coords @ scale.T) @ translation.T
+        assert coords @ scale_translate.T == pytest.approx(expected)
 
     translation_scale = scale @ translation
     with subtests.test(msg="translate->scale results"):
-        expected = coords.dot(translation.T).dot(scale.T)
-        assert coords.dot(translation_scale.T) == pytest.approx(expected)
+        expected = (coords @ translation.T) @ scale.T
+        assert coords @ translation_scale.T == pytest.approx(expected)
 
 
 def test_affine_combination(rng):


### PR DESCRIPTION
- add to_affine to base Transform class and Identity, Translate, Scale and MapAxis subclasses; for all the others transforms, the to_affine method returns None (implementation for the other transforms that can be converted to affine is missing)
- add simplify_affine to base TransformSequence
- add two test for collapsed sequences (need to be expanded, i.e. case limit with all transforms of the sequence with no defined ndim)