### PR TITLE
add benchmark and speed up affine

### DIFF
--- a/bench/conftest.py
+++ b/bench/conftest.py
@@ -1,0 +1,9 @@
+import numpy as np
+import pytest
+
+SEED = 1991
+
+
+@pytest.fixture
+def rng() -> np.random.RandomState:
+    return np.random.RandomState(SEED)

--- a/bench/test_affine.py
+++ b/bench/test_affine.py
@@ -1,0 +1,49 @@
+import pytest
+import numpy as np
+
+
+@pytest.mark.benchmark(group="pad-unpad")
+@pytest.mark.parametrize(
+    ("n_coords",), [(1,), (10,), (100,), (1_000,), (10_000,), (100_000,)]
+)
+class TestPadUnpadCoords:
+    ndim = 3
+
+    def scale_vector(self):
+        return np.asarray([10, 20, 30], float)
+
+    def translation_vector(self):
+        return np.asarray([-0.5, 0.0, 0.5], float)
+
+    def coords(self, rng: np.random.Generator, n_coords: int):
+        return rng.random((n_coords, self.ndim))
+
+    def affine(self, rng: np.random.Generator):
+        m = rng.random((self.ndim + 1, self.ndim + 1))
+        m[-1, :] = 0
+        m[-1, -1] = 1
+        return m
+
+    def test_pad_unpad(self, n_coords, rng, benchmark):
+        affine = self.affine(rng)
+        coords = self.coords(rng, n_coords)
+
+        def fn():
+            c2 = np.concatenate(
+                [coords, np.ones((coords.shape[0], 1), dtype=coords.dtype)], axis=1
+            )
+            inter = c2 @ affine.T
+            out = inter[:, :-1]
+
+        benchmark(fn)
+
+    def test_lin_then_trans(self, n_coords, rng, benchmark):
+        affine = self.affine(rng)
+        coords = self.coords(rng, n_coords)
+
+        def fn():
+            t = affine.T
+            inter = coords @ t[:-1, :-1]
+            inter += t[-1, :-1]
+
+        benchmark(fn)

--- a/bench/test_affine.py
+++ b/bench/test_affine.py
@@ -33,7 +33,7 @@ class TestPadUnpadCoords:
                 [coords, np.ones((coords.shape[0], 1), dtype=coords.dtype)], axis=1
             )
             inter = c2 @ affine.T
-            out = inter[:, :-1]
+            out = inter[:, :-1]  # noqa
 
         benchmark(fn)
 

--- a/justfile
+++ b/justfile
@@ -14,17 +14,17 @@ doc:
 
 # Run linters and type checkers.
 lint:
-    uv run ruff check src tests examples
-    uv run mypy src tests
-    uv run ruff format --check src tests examples
+    uv run ruff check src tests examples bench
+    uv run mypy src tests bench
+    uv run ruff format --check src tests examples bench
 
 fix:
-    uv run ruff check --fix src tests examples
-    uv run ruff format src tests examples
+    uv run ruff check --fix src tests examples bench
+    uv run ruff format src tests examples bench
 
 # Format python code.
 format:
-    uv run ruff format src tests examples
+    uv run ruff format src tests examples bench
 
 # Run unit tests.
 test:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dev = [
     {include-group = "lint"},
     {include-group = "doc"},
     {include-group = "tutorial"},
+    {include-group = "bench"},
 ]
 test = ["pytest", "jax"]
 lint = [
@@ -41,6 +42,9 @@ tutorial = [
     "matplotlib>=3.10.8",
     "pandas>=3.0.2",
 ]
+bench = [
+    "pytest-benchmark>=5.2.3",
+]
 
 [build-system]
 requires = ["uv_build>=0.9.8,<0.10.0"]
@@ -49,3 +53,7 @@ build-backend = "uv_build"
 [tool.mypy]
 ignore_missing_imports = true
 check_untyped_defs = true
+
+[tool.pytest]
+testpaths = ["tests", "bench"]
+addopts = ["--benchmark-skip"]

--- a/src/transformnd/transforms/affine.py
+++ b/src/transformnd/transforms/affine.py
@@ -114,8 +114,8 @@ class Affine(Transform[ArrayT]):
         xp = array_namespace(coords)
         d = xp_device(coords)
         m = self.cast_matrix(xp, d)
-        linear_map = xp.matrix_transpose(m[:-1, :-1])  # type: ignore[attr-undefined]
-        translation = m[:-1, -1]  # type: ignore[attr-undefined]
+        linear_map = xp.matrix_transpose(m[:-1, :-1])  # type: ignore[index]
+        translation = m[:-1, -1]  # type: ignore[index]
 
         out = coords @ linear_map
         out += translation

--- a/src/transformnd/transforms/affine.py
+++ b/src/transformnd/transforms/affine.py
@@ -12,8 +12,7 @@ from numpy.typing import ArrayLike
 
 from copy import copy
 
-from array_api_compat import array_namespace
-from array_api_compat import device as xp_device
+from array_api_compat import array_namespace, device as xp_device
 from ..base import Transform, ArrayT
 from ..util import is_square, none_eq, SpaceTuple, to_single_ndim
 
@@ -55,8 +54,13 @@ class Affine(Transform[ArrayT]):
         spaces: SpaceTuple = (None, None),
     ):
         """
-        Matrix must have shape (D+1, D+1) or (D, D+1);
-        the bottom row is assumed to be [0, 0, ..., 0, 1].
+        Affine transformation matrices' bottom row must be all zeroes except a 1 in the rightmost column.
+
+        Matrix may have shape:
+
+        - (D+1, D+1): an affine transformation matrix (the bottom row will be validated)
+        - (D, D+1): an affine transformation matrix missing the bottom row (it will be added)
+        - (D,): a vector of scales which become the first D elements of a diagonal matrix of size D+1
 
         Parameters
         ----------
@@ -74,7 +78,11 @@ class Affine(Transform[ArrayT]):
         super().__init__(spaces=spaces)
         m = np.asarray(matrix)
 
-        if m.ndim != 2:
+        if m.ndim == 1:
+            scales = m
+            m = np.eye(len(m) + 1, dtype=m.dtype)
+            m[:-1, :-1] *= scales
+        elif m.ndim != 2:
             raise ValueError("Transformation matrix must be 2D")
 
         if m.shape[1] == m.shape[0] + 1:
@@ -83,6 +91,12 @@ class Affine(Transform[ArrayT]):
             m = base
         elif not is_square(m):
             raise ValueError("Transformation matrix must be square")
+        else:
+            bottom_row = m[-1, :]
+            if bottom_row[-1] != 1 or not np.all(bottom_row[:-1] == 0):
+                raise ValueError(
+                    "Transformation matrix is not affine (bottom row must be [0,0,0,...,1])."
+                )
 
         self.matrix = m
         self.ndim = {len(self.matrix) - 1}
@@ -100,11 +114,21 @@ class Affine(Transform[ArrayT]):
         xp = array_namespace(coords)
         d = xp_device(coords)
         m = self.cast_matrix(xp, d)
-        coords = xp.concatenate(
-            [coords, xp.ones((coords.shape[0], 1), dtype=coords.dtype)],  # type: ignore[attr-defined]
-            axis=1,
-        )
-        out: ArrayT = (coords @ m.T)[:, :-1]  # type: ignore[attr-defined]
+        linear_map = xp.matrix_transpose(m[:-1, :-1])  # type: ignore[attr-undefined]
+        translation = m[:-1, -1]  # type: ignore[attr-undefined]
+
+        out = coords @ linear_map
+        out += translation
+
+        ## Padding and then unpadding the coords is slower, especially in C order
+        # coords = xp.concatenate(
+        #     [coords, xp.ones((coords.shape[0], 1), dtype=coords.dtype)],  # type: ignore[attr-defined]
+        #     axis=1,
+        # )
+        # out: ArrayT = (coords @ m.T)[:, :-1]  # type: ignore[attr-defined]
+
+        return out
+
         return out
 
     def invert(self) -> Self | None:

--- a/uv.lock
+++ b/uv.lock
@@ -1187,6 +1187,15 @@ wheels = [
 ]
 
 [[package]]
+name = "py-cpuinfo"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/a8/d832f7293ebb21690860d2e01d8115e5ff6f2ae8bbdc953f0eb0fa4bd2c7/py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690", size = 104716, upload-time = "2022-10-25T20:38:06.303Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/a9/023730ba63db1e494a271cb018dcd361bd2c917ba7004c3e49d5daf795a2/py_cpuinfo-9.0.0-py3-none-any.whl", hash = "sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5", size = 22335, upload-time = "2022-10-25T20:38:27.636Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1240,6 +1249,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-benchmark"
+version = "5.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "py-cpuinfo" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/24/34/9f732b76456d64faffbef6232f1f9dbec7a7c4999ff46282fa418bd1af66/pytest_benchmark-5.2.3.tar.gz", hash = "sha256:deb7317998a23c650fd4ff76e1230066a76cb45dcece0aca5607143c619e7779", size = 341340, upload-time = "2025-11-09T18:48:43.215Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/29/e756e715a48959f1c0045342088d7ca9762a2f509b945f362a316e9412b7/pytest_benchmark-5.2.3-py3-none-any.whl", hash = "sha256:bc839726ad20e99aaa0d11a127445457b4219bdb9e80a1afc4b51da7f96b0803", size = 45255, upload-time = "2025-11-09T18:48:39.765Z" },
 ]
 
 [[package]]
@@ -1538,6 +1560,9 @@ thinplatesplines = [
 ]
 
 [package.dev-dependencies]
+bench = [
+    { name = "pytest-benchmark" },
+]
 dev = [
     { name = "jax" },
     { name = "marimo" },
@@ -1584,6 +1609,7 @@ requires-dist = [
 provides-extras = ["thinplatesplines", "movingleastsquares", "pandas", "shapely"]
 
 [package.metadata.requires-dev]
+bench = [{ name = "pytest-benchmark", specifier = ">=5.2.3" }]
 dev = [
     { name = "jax" },
     { name = "marimo", specifier = ">=0.9" },

--- a/uv.lock
+++ b/uv.lock
@@ -1572,6 +1572,7 @@ dev = [
     { name = "pdoc" },
     { name = "prek" },
     { name = "pytest" },
+    { name = "pytest-benchmark" },
     { name = "ruff" },
     { name = "types-shapely" },
 ]
@@ -1619,6 +1620,7 @@ dev = [
     { name = "pdoc", specifier = ">=16.0.0" },
     { name = "prek", specifier = ">=0.3.9" },
     { name = "pytest" },
+    { name = "pytest-benchmark", specifier = ">=5.2.3" },
     { name = "ruff" },
     { name = "types-shapely", specifier = ">=2.1.0.20260408" },
 ]


### PR DESCRIPTION
Affine transformations require padding the coordinate array with a column of 1s and then trimming it off. This decomposes the affine into a linear map and a translation and applies them in sequence, which benchmarks suggest is faster.