### PR TITLE
remove direct scipy dependency for TPS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,9 @@ dependencies = [
 license = "MIT"
 
 [project.optional-dependencies]
-thinplatesplines = ["morphops>=0.1.13", "scipy>=1.17.1"]
+thinplatesplines = [
+    "morphops>=0.1.13",
+]
 movingleastsquares = ["molesq>=0.4.0"]
 pandas = ["pandas>=3.0.2"]
 shapely = ["shapely>=2.1.2"]

--- a/src/transformnd/transforms/thinplate.py
+++ b/src/transformnd/transforms/thinplate.py
@@ -14,16 +14,6 @@ from ..util import check_ndim, invert_spaces
 
 logger = logging.getLogger(__name__)
 
-try:
-    from scipy.spatial.distance import cdist
-
-    # Replace morphops's original slow distance_matrix function
-    mops.lmk_util.distance_matrix = cdist  # type: ignore
-except ImportError:
-    logger.warning(
-        "scipy not present; morphops-based transformations may be slower than necessary"
-    )
-
 
 class ThinPlateSplines(Transform[np.ndarray]):
     """Thin plate splines transforms.

--- a/uv.lock
+++ b/uv.lock
@@ -1556,7 +1556,6 @@ shapely = [
 ]
 thinplatesplines = [
     { name = "morphops" },
-    { name = "scipy" },
 ]
 
 [package.dev-dependencies]
@@ -1603,7 +1602,6 @@ requires-dist = [
     { name = "networkx", specifier = ">=3" },
     { name = "numpy", specifier = ">=2" },
     { name = "pandas", marker = "extra == 'pandas'", specifier = ">=3.0.2" },
-    { name = "scipy", marker = "extra == 'thinplatesplines'", specifier = ">=1.17.1" },
     { name = "shapely", marker = "extra == 'shapely'", specifier = ">=2.1.2" },
     { name = "typing-extensions", specifier = ">=4.15.0" },
 ]


### PR DESCRIPTION
This was previously used to replace morphops' slow distance matrix function, but that now just wraps the scipy function anyway