### PR TITLE
Support up/down projections

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Methods which SHOULD be implemented if applicable:
 
 - `to_device`: if any of the transformation's parameters need to be placed on a specific device (e.g. affine matrices on the GPU)
 - `is_identity`: if you can cheaply check whether your transformation is an identity transformation. The base class implementation returns `False`.
-- `into_affine`: if your transformation can be represented as an affine matrix. The base class implementation returns `None`.
+- `to_affine`: if your transformation can be represented as an affine matrix. The base class implementation returns `None`.
 - `invert`: if your transformation can be inverted (default None if not)
   - This automatically implements `__invert__` (the `~my_transform` operator), which raises NotImplemented if `invert` would return `None`.
 

--- a/src/transformnd/__init__.py
+++ b/src/transformnd/__init__.py
@@ -3,7 +3,8 @@
 """
 
 from .base import Transform, TransformSequence, TransformWrapper
-from .util import SpaceRef, TransformSignature, check_ndim
+from .util import SpaceRef, check_ndim
+from .types import Spaces, TransformSignature, NDims
 from . import transforms
 from . import adapters
 from .graph import TransformGraph
@@ -21,4 +22,6 @@ __all__ = [
     "check_ndim",
     "transforms",
     "adapters",
+    "Spaces",
+    "NDims",
 ]

--- a/src/transformnd/__init__.py
+++ b/src/transformnd/__init__.py
@@ -3,7 +3,7 @@
 """
 
 from .base import Transform, TransformSequence, TransformWrapper
-from .util import SpaceRef, check_ndim
+from .util import SpaceRef
 from .types import Spaces, TransformSignature, NDims
 from . import transforms
 from . import adapters
@@ -19,7 +19,6 @@ __all__ = [
     "TransformWrapper",
     "TransformSignature",
     "SpaceRef",
-    "check_ndim",
     "transforms",
     "adapters",
     "Spaces",

--- a/src/transformnd/base.py
+++ b/src/transformnd/base.py
@@ -11,16 +11,13 @@ from array_api_compat import array_namespace
 
 from .util import (
     SpaceRef,
-    TransformSignature,
-    check_ndim,
-    dim_intersection,
-    invert_spaces,
     same_or_none,
     space_str,
-    window,
-    SpaceTuple,
     ArrayT,
 )
+from itertools import pairwise
+
+from .types import TransformSignature, Spaces, NDims
 
 if TYPE_CHECKING:
     from .transforms import Affine
@@ -29,40 +26,27 @@ if TYPE_CHECKING:
 class Transform[ArrayT](ABC):
     """Base class for transforms."""
 
-    ndim: set[int] | None = None
-
     def __init__(
         self,
+        ndims: NDims,
         *,
-        spaces: SpaceTuple = (None, None),
+        spaces: Spaces = Spaces(None, None),
     ):
         """
         Parameters
         ----------
-        spaces : tuple[SpaceRef, SpaceRef]
+        spaces
             Optional source and target spaces
         """
-        self.spaces = spaces
-
-    @property
-    def source_space(self):
-        return self.spaces[0]
-
-    @property
-    def target_space(self):
-        return self.spaces[1]
+        self.ndims: NDims = ndims
+        self.spaces: Spaces = spaces
 
     def is_identity(self) -> bool:
         """Whether this is a no-op transformation."""
         return False
 
-    def to_affine(self, ndim: int | None = None) -> Affine[ArrayT] | None:
+    def to_affine(self) -> Affine[ArrayT] | None:
         """Convert the transform into affine, if conversion is possible.
-
-        Parameters
-        ----------
-        dim: int, optional
-            Total number of dimensions; If None, dim is set equal to self.ndim.
 
         Returns
         -------
@@ -73,7 +57,7 @@ class Transform[ArrayT](ABC):
         return None
 
     def _validate_coords(self, coords: ArrayT) -> ArrayT:
-        """Check that dimension of coords are supported.
+        """Check that input coordinates are of the correct shape.
 
         Also ensure that coords is a 2D array.
 
@@ -90,7 +74,11 @@ class Transform[ArrayT](ABC):
         xp = array_namespace(coords)
         if xp.ndim(coords) != 2:
             raise ValueError("Coords must be a 2D array")
-        check_ndim(xp.shape(coords)[1], self.ndim)
+        dim = xp.shape(coords)[1]
+        if xp.shape(coords)[1] != self.ndims.source:
+            raise ValueError(
+                f"Coords must have dimensionality {self.ndims.source}, got {dim}"
+            )
         return coords
 
     @abstractmethod
@@ -111,8 +99,6 @@ class Transform[ArrayT](ABC):
 
     def invert(self) -> Transform | None:
         """Invert the transformation, returning `None` if not possible."""
-        if self.is_identity():
-            return copy(self)
         return None
 
     def __invert__(self) -> Transform:
@@ -167,10 +153,10 @@ class Transform[ArrayT](ABC):
         """
         if not isinstance(other, Transform):
             return NotImplemented
-        transforms = get_transform_list(self) + get_transform_list(other)
+        transforms = as_transform_list(self) + as_transform_list(other)
         return TransformSequence[ArrayT](
             transforms,
-            spaces=(self.source_space, other.target_space),
+            spaces=Spaces(self.spaces.source, other.spaces.target),
         )
 
     def __ror__(self, other: Transform[ArrayT]) -> TransformSequence[ArrayT]:
@@ -188,16 +174,16 @@ class Transform[ArrayT](ABC):
         """
         if not isinstance(other, Transform):
             return NotImplemented
-        transforms = get_transform_list(other) + get_transform_list(self)
+        transforms = as_transform_list(other) + as_transform_list(self)
         return TransformSequence(
             transforms,
-            spaces=(other.source_space, self.target_space),
+            spaces=Spaces(other.spaces.source, self.spaces.target),
         )
 
     def __str__(self) -> str:
         cls_name = type(self).__name__
-        src = space_str(self.source_space)
-        tgt = space_str(self.target_space)
+        src = space_str(self.spaces.source)
+        tgt = space_str(self.spaces.target)
         return f"{cls_name}[{src}->{tgt}]"
 
 
@@ -207,9 +193,10 @@ class TransformWrapper(Transform[ArrayT]):
     def __init__(
         self,
         fn: TransformSignature[ArrayT],
-        ndim: set[int] | int | None = None,
+        in_ndim: int,
+        out_ndim: int,
         *,
-        spaces: SpaceTuple = (None, None),
+        spaces: Spaces = Spaces(None, None),
     ):
         """Wrapper around an arbitrary function.
 
@@ -223,13 +210,8 @@ class TransformWrapper(Transform[ArrayT]):
         spaces : tuple[SpaceRef, SpaceRef]
             Optional source and target spaces
         """
-        super().__init__(spaces=spaces)
+        super().__init__(NDims(in_ndim, out_ndim), spaces=spaces)
         self.fn = fn
-        if ndim is not None:
-            if isinstance(ndim, int):
-                self.ndim = {ndim}
-            else:
-                self.ndim = set(ndim)
 
     def apply(self, coords: ArrayT) -> ArrayT:
         self._validate_coords(coords)
@@ -241,12 +223,12 @@ def _with_spaces(
     source_space: SpaceRef | None = None,
     target_space: SpaceRef | None = None,
 ) -> Transform[ArrayT]:
-    src_tgt = (t.source_space, t.target_space)
+    src_tgt = (t.spaces.source, t.spaces.target)
     src = same_or_none(src_tgt[0], source_space, default=None)
     tgt = same_or_none(src_tgt[1], target_space, default=None)
     if (src, tgt) != src_tgt:
         t = copy(t)
-        t.spaces = (src, tgt)
+        t.spaces = Spaces(src, tgt)
     return t
 
 
@@ -255,9 +237,9 @@ def infer_spaces(
 ) -> list[Transform[ArrayT]]:
     prev_tgts = [source_space]
     next_srcs = []
-    for t1, t2 in window(transforms, 2):
-        prev_tgts.append(t1.target_space)
-        next_srcs.append(t2.source_space)
+    for t1, t2 in pairwise(transforms):
+        prev_tgts.append(t1.spaces.target)
+        next_srcs.append(t2.spaces.source)
 
     next_srcs.append(target_space)
 
@@ -267,7 +249,7 @@ def infer_spaces(
     return out
 
 
-def get_transform_list(t: Transform[ArrayT]) -> list[Transform[ArrayT]]:
+def as_transform_list(t: Transform[ArrayT]) -> list[Transform[ArrayT]]:
     if isinstance(t, TransformSequence):
         return t.transforms.copy()
     else:
@@ -281,7 +263,7 @@ class TransformSequence(Transform[ArrayT], Sequence[Transform[ArrayT]]):
         self,
         transforms: Sequence[Transform[ArrayT]],
         *,
-        spaces: SpaceTuple = (None, None),
+        spaces: Spaces = Spaces(None, None),
     ) -> None:
         """Combine transforms by chaining them.
 
@@ -303,21 +285,18 @@ class TransformSequence(Transform[ArrayT], Sequence[Transform[ArrayT]]):
             If spaces are incompatible.
         """
         ts = infer_spaces(transforms, *spaces)
-        if ts:
-            spaces = (ts[0].source_space, ts[-1].target_space)
+        if not ts:
+            raise ValueError("Empty transform sequence")
+
+        spaces = Spaces(ts[0].spaces.source, ts[-1].spaces.target)
+        ndims = NDims(ts[0].ndims.source, ts[-1].ndims.target)
 
         super().__init__(
+            ndims,
             spaces=spaces,
         )
 
         self.transforms: list[Transform[ArrayT]] = ts
-
-        self.ndim = None
-        for t in self.transforms:
-            self.ndim = dim_intersection(self.ndim, t.ndim)
-
-        if self.ndim is not None and len(self.ndim) == 0:
-            raise ValueError("Transforms have incompatible dimensionalities")
 
     def __iter__(self) -> Iterator[Transform[ArrayT]]:
         """Iterate through component transforms.
@@ -344,7 +323,7 @@ class TransformSequence(Transform[ArrayT], Sequence[Transform[ArrayT]]):
             return None
         return type(self)(
             transforms,
-            spaces=invert_spaces(self.spaces),
+            spaces=self.spaces.invert(),
         )
 
     def apply(self, coords: ArrayT) -> ArrayT:
@@ -369,7 +348,7 @@ class TransformSequence(Transform[ArrayT], Sequence[Transform[ArrayT]]):
         -------
         List[SpaceRef]
         """
-        spaces = [self.source_space] + [t.target_space for t in self.transforms]
+        spaces = [self.spaces.source] + [t.spaces.target for t in self.transforms]
         if skip_none:
             spaces = [s for s in spaces if s is not None]
         return spaces
@@ -387,7 +366,7 @@ class TransformSequence(Transform[ArrayT], Sequence[Transform[ArrayT]]):
     def is_identity(self) -> bool:
         return all(t.is_identity() for t in self)
 
-    def simplify(self, ndim: int | None = None, drop_inverse: bool = False):
+    def simplify(self, drop_inverse: bool = True):
         """Reduce the number of transformations in this sequence if possible.
 
         - Compose consecutive transformations which can be expressed as affines
@@ -402,21 +381,13 @@ class TransformSequence(Transform[ArrayT], Sequence[Transform[ArrayT]]):
         """
         from .transforms.bijection import Bijection
 
-        if ndim is None:
-            if self.ndim is not None and len(self.ndim) == 1:
-                ndim = tuple(self.ndim)[0]
-        else:
-            check_ndim(ndim, self.ndim)
-
         out: list[Transform[ArrayT]] = []
         affine = None
         for t in self.transforms:
             if drop_inverse and isinstance(t, Bijection):
                 t = t.forward
 
-            new_affine = None
-            if ndim is not None:
-                new_affine = t.to_affine(ndim)
+            new_affine = t.to_affine()
 
             if new_affine is None:
                 if affine is not None:
@@ -441,6 +412,6 @@ def add_to_output(transform: Transform, lst: list[Transform]) -> bool:
         return False
 
     transform = copy(transform)
-    transform.spaces = (None, None)
+    transform.spaces = Spaces(None, None)
     lst.append(transform)
     return True

--- a/src/transformnd/constants.py
+++ b/src/transformnd/constants.py
@@ -1,0 +1,1 @@
+UNSPECIFIED_SPACE_NAME = "???"

--- a/src/transformnd/extents/base.py
+++ b/src/transformnd/extents/base.py
@@ -4,7 +4,8 @@ from abc import ABC, abstractmethod
 class Extents[ArrayT](ABC):
     """Base class for determining whether coordinates are "inside" a space."""
 
-    ndim: set[int] | None = None
+    def __init__(self, ndim: int) -> None:
+        self.ndim = ndim
 
     @abstractmethod
     def contains(self, coords: ArrayT) -> ArrayT: ...

--- a/src/transformnd/extents/bounding_box.py
+++ b/src/transformnd/extents/bounding_box.py
@@ -1,6 +1,6 @@
 from functools import lru_cache
 from array_api_compat import array_namespace
-from ..util import ArrayT, are_coords
+from ..util import ArrayT
 from .base import Extents
 from array_api_compat import device as xp_device
 
@@ -13,9 +13,9 @@ class BoundingBox(Extents[ArrayT]):
         if len(xp.shape(mins)) != 1:
             raise ValueError("mins and maxes must be 1D")
 
-        self.ndim = {xp.shape(mins)[0]}
         self.mins = mins
         self.maxes = maxes
+        super().__init__(xp.shape(mins)[0])
 
     @lru_cache()
     def extents_cast(self, namespace, device) -> tuple[ArrayT, ArrayT]:
@@ -25,7 +25,13 @@ class BoundingBox(Extents[ArrayT]):
         )
 
     def _validate_coords(self, coords: ArrayT) -> ArrayT:
-        return are_coords(coords, self.ndim)
+        xp = array_namespace(coords)
+        if xp.ndim(coords) != 2:
+            raise ValueError("Coords must be a 2D array")
+        dim = xp.shape(coords)[1]
+        if xp.shape(coords)[1] != self.ndim:
+            raise ValueError(f"Coords must have dimensionality {self.ndim}, got {dim}")
+        return coords
 
     def contains(self, coords: ArrayT) -> ArrayT:
         coords = self._validate_coords(coords)

--- a/src/transformnd/graph.py
+++ b/src/transformnd/graph.py
@@ -8,7 +8,9 @@ from collections.abc import Iterable, Iterator
 import networkx as nx
 
 from .base import Transform, TransformSequence
-from .util import SpaceRef, chain_or, dim_intersection, window, ArrayT
+from .util import SpaceRef, chain_or, ArrayT
+from .types import Spaces
+from itertools import pairwise
 
 
 def split_sequence(seq: TransformSequence[ArrayT]) -> Iterator[Transform[ArrayT]]:
@@ -28,12 +30,12 @@ def split_sequence(seq: TransformSequence[ArrayT]) -> Iterator[Transform[ArrayT]
     """
     this_seq = []
     for t in seq.transforms:
-        if t.source_space is not None and t.target_space is not None:
+        if t.spaces.source is not None and t.spaces.target is not None:
             yield t
             continue
 
         this_seq.append(t)
-        if t.target_space is not None:
+        if t.spaces.target is not None:
             yield TransformSequence(this_seq)
             this_seq = []
 
@@ -45,6 +47,32 @@ class SimplifyConfig:
 
     drop_inverse: bool = False
     """Drop explicit inverses in bijection transformations."""
+
+
+class NDimRegistries:
+    def __init__(self, perm: dict[SpaceRef, int]) -> None:
+        self.perm = perm
+        self.temp: dict[SpaceRef, int] = dict()
+
+    def _check_inner(
+        self, space: SpaceRef, ndim: int, reg: dict[SpaceRef, int], add: bool = False
+    ):
+        val = reg.get(space)
+        if val is None:
+            if add:
+                reg[space] = ndim
+            return None
+        if val != ndim:
+            raise ValueError(
+                f"New transform implies space {space} is {ndim}D, but it is already registered as {val}D"
+            )
+
+    def merge(self):
+        self.perm.update(self.temp)
+
+    def check(self, space: SpaceRef, ndim: int):
+        self._check_inner(space, ndim, self.perm)
+        self._check_inner(space, ndim, self.temp, True)
 
 
 class TransformGraph[ArrayT]:
@@ -59,6 +87,7 @@ class TransformGraph[ArrayT]:
     def __init__(self):
         self.graph = nx.DiGraph()
         self.ndim: set[int] | None = None
+        self.space_ndims: dict[SpaceRef, int] = dict()
 
     def add_transforms(self, transforms: Iterable[Transform[ArrayT]]) -> int:
         """
@@ -78,27 +107,23 @@ class TransformGraph[ArrayT]:
         edges: dict[tuple[SpaceRef, SpaceRef], Transform[ArrayT]] = dict()
         self.get_sequence.cache_clear()
 
-        ndim = self.ndim
+        registry = NDimRegistries(self.space_ndims)
 
         for t in transforms:
-            ndim = dim_intersection(ndim, t.ndim)
-            if ndim is not None and len(ndim) == 0:
-                raise ValueError("This TransformGraph supports no dimensionality")
-
             if isinstance(t, TransformSequence):
                 ts = list(split_sequence(t))
             else:
                 ts = [t]
 
             for t2 in ts:
-                if chain_or(t2.source_space, t2.target_space, default=None) is None:
+                if chain_or(t2.spaces.source, t2.spaces.target, default=None) is None:
                     raise ValueError(
                         "All transforms in a graph "
                         "need explicit source and target spaces"
                     )
-                edges[(t2.source_space, t2.target_space)] = t2
-
-        self.ndim = ndim
+                registry.check(t2.spaces.source, t2.ndims.source)
+                registry.check(t2.spaces.target, t2.ndims.target)
+                edges[(t2.spaces.source, t2.spaces.target)] = t2
 
         count = 0
 
@@ -112,6 +137,8 @@ class TransformGraph[ArrayT]:
                 except NotImplementedError:
                     pass
 
+        registry.merge()
+
         return count
 
     @lru_cache()
@@ -119,7 +146,7 @@ class TransformGraph[ArrayT]:
         self,
         source_space: SpaceRef,
         target_space: SpaceRef,
-        simplify: SimplifyConfig | None = None,
+        full: bool = False,
     ) -> TransformSequence[ArrayT]:
         """Get the shortest TransformSequence for transforming between two spaces.
 
@@ -127,12 +154,9 @@ class TransformGraph[ArrayT]:
         ----------
         source_space : SpaceRef
         target_space : SpaceRef
-        simplify : bool
-            Whether to simplify the transform sequence; see `TransformSequence.simplify`.
-        drop_inverse : bool
-            If `simplify==True`, whether to drop explicit inverses.
-            See `TransformSequence.simplify` for details.
-            Ignored if `simplify==False`.
+        full : bool
+            By default, simplifies consecutive affines and drops bijections' inverse form.
+            If `full` is True, keeps each transformation as-is.
 
         Returns
         -------
@@ -143,14 +167,14 @@ class TransformGraph[ArrayT]:
             transforms = []
         else:
             transforms = [
-                self.graph.edges[src, tgt]["transform"] for src, tgt in window(path, 2)
+                self.graph.edges[src, tgt]["transform"] for src, tgt in pairwise(path)
             ]
         seq = TransformSequence(
             transforms,
-            spaces=(source_space, target_space),
+            spaces=Spaces(source_space, target_space),
         )
-        if simplify is not None:
-            seq = seq.simplify(ndim=simplify.ndim, drop_inverse=simplify.drop_inverse)
+        if not full:
+            seq = seq.simplify(drop_inverse=False)
         return seq
 
     def transform(
@@ -158,8 +182,6 @@ class TransformGraph[ArrayT]:
         source_space: SpaceRef,
         target_space: SpaceRef,
         coords: ArrayT,
-        *,
-        simplify=SimplifyConfig(drop_inverse=True),
     ) -> ArrayT:
         """Transform coordinates from one space to another,
         possibly via intermediates.
@@ -174,7 +196,7 @@ class TransformGraph[ArrayT]:
         -------
         ArrayT
         """
-        t = self.get_sequence(source_space, target_space, simplify)
+        t = self.get_sequence(source_space, target_space)
         return t.apply(coords)
 
     def __iter__(self) -> Iterator[Transform[ArrayT]]:

--- a/src/transformnd/graph.py
+++ b/src/transformnd/graph.py
@@ -86,7 +86,6 @@ class TransformGraph[ArrayT]:
 
     def __init__(self):
         self.graph = nx.DiGraph()
-        self.ndim: set[int] | None = None
         self.space_ndims: dict[SpaceRef, int] = dict()
 
     def add_transforms(self, transforms: Iterable[Transform[ArrayT]]) -> int:

--- a/src/transformnd/transforms/affine.py
+++ b/src/transformnd/transforms/affine.py
@@ -14,7 +14,8 @@ from copy import copy
 
 from array_api_compat import array_namespace, device as xp_device
 from ..base import Transform, ArrayT
-from ..util import is_square, none_eq, SpaceTuple, to_single_ndim
+from ..util import as_floats, none_eq
+from ..types import NDims, Spaces
 
 
 def arg_as_array(arg, ndim: int | None) -> np.ndarray:
@@ -45,28 +46,19 @@ class Affine(Transform[ArrayT]):
     so the transform works transparently with NumPy, JAX, PyTorch, CuPy, etc.
     """
 
-    matrix: np.ndarray
-
     def __init__(
         self,
         matrix: ArrayLike,
         *,
-        spaces: SpaceTuple = (None, None),
+        spaces: Spaces = Spaces(None, None),
     ):
         """
-        Affine transformation matrices' bottom row must be all zeroes except a 1 in the rightmost column.
-
-        Matrix may have shape:
-
-        - (D+1, D+1): an affine transformation matrix (the bottom row will be validated)
-        - (D, D+1): an affine transformation matrix missing the bottom row (it will be added)
-        - (D,): a vector of scales which become the first D elements of a diagonal matrix of size D+1
-
         Parameters
         ----------
         matrix : ArrayLike
-            Affine transformation matrix. Any array-like (including JAX/PyTorch
-            arrays) is accepted and converted to NumPy for storage.
+            Affine transformation matrix,
+            i.e. a 2D array-like with shape `(Di + 1, Do + 1)`,
+            where the bottom row is all 0s except in the rightmost column, which is 1.
         spaces : tuple[SpaceRef, SpaceRef]
             Optional source and target spaces
 
@@ -75,30 +67,21 @@ class Affine(Transform[ArrayT]):
         ValueError
             Malformed matrix.
         """
-        super().__init__(spaces=spaces)
-        m = np.asarray(matrix)
+        m = as_floats(matrix)
+        if m.ndim != 2:
+            raise ValueError("Affine matrix must be 2D")
 
-        if m.ndim == 1:
-            scales = m
-            m = np.eye(len(m) + 1, dtype=m.dtype)
-            m[:-1, :-1] *= scales
-        elif m.ndim != 2:
-            raise ValueError("Transformation matrix must be 2D")
+        bottom_row = m[-1, :]
+        expected = np.zeros_like(bottom_row)
+        expected[-1] = 1
+        if not np.allclose(bottom_row, expected):
+            raise ValueError(
+                f"Transformation matrix is not affine (expected bottom row {expected}, got {bottom_row})."
+            )
 
-        if m.shape[1] == m.shape[0] + 1:
-            base = np.eye(m.shape[1], dtype=m.dtype)
-            base[:-1, :] = m
-            m = base
-        elif not is_square(m):
-            raise ValueError("Transformation matrix must be square")
-        else:
-            bottom_row = m[-1, :]
-            if bottom_row[-1] != 1 or not np.all(bottom_row[:-1] == 0):
-                raise ValueError(
-                    "Transformation matrix is not affine (bottom row must be [0,0,0,...,1])."
-                )
+        super().__init__(NDims(m.shape[0] - 1, m.shape[1] - 1), spaces=spaces)
 
-        self.matrix = m
+        self.matrix: np.ndarray = m
 
         self._linear_map: np.ndarray | None = m[:-1, :-1]
         if np.allclose(
@@ -110,11 +93,7 @@ class Affine(Transform[ArrayT]):
         if np.allclose(np.zeros_like(self._translation), self._translation):
             self._translation = None
 
-        self.ndim = {len(self.matrix) - 1}
-
-    def to_affine(self, ndim: int | None = None) -> Self | None:
-        # check that if ndim is given, it matches expectation
-        to_single_ndim(ndim, self.ndim)
+    def to_affine(self) -> Self | None:
         return self
 
     def cast_matrix(self, namespace, device) -> ArrayT:
@@ -155,7 +134,7 @@ class Affine(Transform[ArrayT]):
 
         return type(self)(
             inv,
-            spaces=(self.spaces[1], self.spaces[0]),
+            spaces=self.spaces.invert(),
         )
 
     def __matmul__(self, rhs: Affine[ArrayT]) -> Affine[ArrayT]:
@@ -182,11 +161,11 @@ class Affine(Transform[ArrayT]):
             raise ValueError(
                 "Cannot multiply affine matrices of different dimensionality"
             )
-        if not none_eq(self.target_space, rhs.source_space):
+        if not none_eq(self.spaces.target, rhs.spaces.source):
             raise ValueError("Affine transforms do not share a space")
         return Affine(
             self.matrix @ rhs.matrix,
-            spaces=(self.source_space, rhs.target_space),
+            spaces=Spaces(self.spaces.source, rhs.spaces.target),
         )
 
     def to_device(self, xp, device=None) -> "Affine[ArrayT]":
@@ -215,9 +194,9 @@ class Affine(Transform[ArrayT]):
     def from_linear_map(
         cls,
         linear_map: ArrayLike,
-        translation=0,
+        translation: ArrayLike | None = None,
         *,
-        spaces: SpaceTuple = (None, None),
+        spaces: Spaces = Spaces(None, None),
     ) -> Affine[ArrayT]:
         """Create an augmented affine matrix from a linear map,
         with an optional translation.
@@ -225,7 +204,7 @@ class Affine(Transform[ArrayT]):
         Parameters
         ----------
         linear_map : ArrayLike
-            Shape (D, D)
+            Shape `(Di, Do)`
         translation : ArrayLike, optional
             Translation to add to the matrix, by default 0
         spaces : tuple[SpaceRef, SpaceRef]
@@ -235,11 +214,21 @@ class Affine(Transform[ArrayT]):
         -------
         AffineTransform
         """
-        lin_map = np.asarray(linear_map)
-        side = len(lin_map) + 1
-        matrix = np.eye(side, dtype=lin_map.dtype)
+        lin_map = as_floats(linear_map)
+        if lin_map.ndim != 2:
+            raise ValueError(f"Linear map must be 2D; got shape {lin_map.shape}")
+        matrix = np.zeros_like(
+            lin_map, shape=(lin_map.shape[0] + 1, lin_map.shape[1] + 1)
+        )
         matrix[:-1, :-1] = lin_map
-        matrix[:-1, -1] = translation
+        matrix[-1, -1] = 1
+        if translation is not None:
+            t = as_floats(translation)
+            if len(t) != lin_map.shape[0]:
+                raise ValueError(
+                    "Translation array must be the same length as linear map columns"
+                )
+            matrix[:-1, -1] = translation
         return cls(matrix, spaces=spaces)
 
     @classmethod
@@ -247,7 +236,7 @@ class Affine(Transform[ArrayT]):
         cls,
         ndim: int,
         *,
-        spaces: SpaceTuple = (None, None),
+        spaces: Spaces = Spaces(None, None),
     ) -> Affine[ArrayT]:
         """Create an identity affine transformation.
 
@@ -267,16 +256,14 @@ class Affine(Transform[ArrayT]):
     def translation(
         cls,
         translation: ArrayLike,
-        ndim: int | None = None,
         *,
-        spaces: SpaceTuple = (None, None),
+        spaces: Spaces = Spaces(None, None),
     ) -> Affine[ArrayT]:
         """Create an affine translation.
 
         Parameters
         ----------
         translation : ArrayLike
-            If scalar, broadcast to ndim.
         ndim : int, optional
             If translation is scalar, how many dims to use.
         spaces : tuple[SpaceRef, SpaceRef]
@@ -286,7 +273,9 @@ class Affine(Transform[ArrayT]):
         -------
         AffineTransform
         """
-        t = arg_as_array(translation, ndim)
+        t = as_floats(translation)
+        if t.ndim != 1:
+            raise ValueError(f"Translation array must be 1D; got shape {t.shape}")
         m = np.eye(len(t) + 1, dtype=t.dtype)
         m[:-1, -1] = t
         return cls(m, spaces=spaces)
@@ -295,9 +284,8 @@ class Affine(Transform[ArrayT]):
     def scaling(
         cls,
         scale: ArrayLike,
-        ndim: int | None = None,
         *,
-        spaces: SpaceTuple = (None, None),
+        spaces: Spaces = Spaces(None, None),
     ) -> Affine[ArrayT]:
         """Create an affine scaling.
 
@@ -314,10 +302,10 @@ class Affine(Transform[ArrayT]):
         -------
         AffineTransform
         """
-        s = arg_as_array(scale, ndim)
-        m = np.eye(len(s) + 1, dtype=s.dtype)
-        m[:-1, :-1] *= s
-        return cls(m, spaces=spaces)
+        s = as_floats(scale)
+        if s.ndim != 1:
+            raise ValueError(f"Scale array must be 1D; got shape {s.shape}")
+        return cls.from_linear_map(np.diag(s), spaces=spaces)
 
     @classmethod
     def reflection(
@@ -325,7 +313,7 @@ class Affine(Transform[ArrayT]):
         axis: Union[int, Container[int]],
         ndim: int,
         *,
-        spaces: SpaceTuple = (None, None),
+        spaces: Spaces = Spaces(None, None),
     ) -> Affine[ArrayT]:
         """Create an affine reflection.
 
@@ -354,7 +342,7 @@ class Affine(Transform[ArrayT]):
         degrees=True,
         clockwise=False,
         *,
-        spaces: SpaceTuple = (None, None),
+        spaces: Spaces = Spaces(None, None),
     ) -> Affine[ArrayT]:
         """Create a 2D affine rotation.
 
@@ -388,7 +376,7 @@ class Affine(Transform[ArrayT]):
         clockwise=False,
         order=(0, 1, 2),
         *,
-        spaces: SpaceTuple = (None, None),
+        spaces: Spaces = Spaces(None, None),
     ) -> Affine[ArrayT]:
         """Create a 3D affine rotation.
 
@@ -446,7 +434,7 @@ class Affine(Transform[ArrayT]):
         factor: Union[float, np.ndarray],
         ndim: int | None = None,
         *,
-        spaces: SpaceTuple = (None, None),
+        spaces: Spaces = Spaces(None, None),
     ) -> Affine[ArrayT]:
         """Create an affine shear.
 
@@ -500,13 +488,10 @@ class Affine(Transform[ArrayT]):
             return NotImplemented
         return np.array_equal(self.matrix, other.matrix) and self.spaces == other.spaces
 
-    def into_affine(self, ndim: int | None = None) -> Affine[ArrayT]:
-        ndim = to_single_ndim(ndim, self.ndim)
-        return self
-
     def is_identity(self) -> bool:
         xp = array_namespace(self.matrix)
-        assert self.ndim is not None
-        ndim = list(self.ndim).pop()
-        identity = xp.eye(ndim + 1, dtype=self.matrix.dtype, device=self.matrix.device)
+        sh = xp.shape(self.matrix)
+        if sh[0] != sh[1]:
+            return False
+        identity = xp.eye(sh[0], dtype=self.matrix.dtype, device=self.matrix.device)
         return xp.all(xp.equal(self.matrix, identity))

--- a/src/transformnd/transforms/bijection.py
+++ b/src/transformnd/transforms/bijection.py
@@ -5,7 +5,7 @@ from array_api_compat import array_namespace
 from transformnd.transforms.affine import Affine
 
 from ..base import Transform, ArrayT
-from ..util import SpaceTuple, dim_intersection, invert_spaces
+from ..types import Spaces
 
 
 class Bijection(Transform[ArrayT]):
@@ -13,14 +13,12 @@ class Bijection(Transform[ArrayT]):
 
     For example, x -> y and y -> x"""
 
-    # ndim: Optional[Set[int]] = set(2)
-
     def __init__(
         self,
         forward: Transform[ArrayT],
         inverse: Transform[ArrayT],
         *,
-        spaces: SpaceTuple = (None, None),
+        spaces: Spaces = Spaces(None, None),
     ):
         """Base class for transformations.
 
@@ -32,28 +30,26 @@ class Bijection(Transform[ArrayT]):
 
         self.forward = forward
         self.inverse = inverse
-        ndim = dim_intersection(forward.ndim, inverse.ndim)
-        if ndim is not None and len(ndim) == 0:
+        if forward.ndims != inverse.ndims.invert():
             raise ValueError(
-                "forward and inverse transforms do not share a dimensionality"
+                f"Bijection dimensionalities mismatch: fwd:{forward.ndims}, inv:{inverse.ndims}"
             )
-        self.ndim = ndim
-        self.spaces = spaces
+        super().__init__(self.forward.ndims, spaces=spaces)
 
     def apply(self, coords: ArrayT) -> ArrayT:
         return self.forward.apply(coords)
 
     def invert(self) -> Self | None:
-        return type(self)(self.inverse, self.forward, spaces=invert_spaces(self.spaces))
+        return type(self)(self.inverse, self.forward, spaces=self.spaces.invert())
 
     def is_identity(self) -> bool:
         return self.forward.is_identity() and self.inverse.is_identity()
 
-    def to_affine(self, ndim: int | None = None) -> Affine[ArrayT] | None:
-        fwd = self.forward.to_affine(ndim)
+    def to_affine(self) -> Affine[ArrayT] | None:
+        fwd = self.forward.to_affine()
         if fwd is None:
             return None
-        inv = self.inverse.to_affine(ndim)
+        inv = self.inverse.to_affine()
         if inv is None:
             return None
 

--- a/src/transformnd/transforms/by_dimension.py
+++ b/src/transformnd/transforms/by_dimension.py
@@ -3,7 +3,8 @@ from array_api_compat import array_namespace
 from .simple import Identity
 
 from ..base import Transform
-from ..util import SpaceTuple, ArrayT, check_ndim, invert_spaces
+from ..util import ArrayT
+from ..types import NDims, Spaces
 
 
 class SubTransform[ArrayT]:
@@ -18,7 +19,6 @@ class SubTransform[ArrayT]:
 
         self.input_axes = input_axes
         if output_axes is None:
-            # this needs to be adjusted if we want to support drop and add axis
             self.output_axes = input_axes
         else:
             self.output_axes = output_axes
@@ -26,17 +26,15 @@ class SubTransform[ArrayT]:
         in_ndim = len(self.input_axes)
         out_ndim = len(self.output_axes)
 
-        if len(set(self.input_axes)) != in_ndim:
-            raise ValueError("Input axes must be unique and non-empty")
-        if len(set(self.output_axes)) != out_ndim:
-            raise ValueError("Output axes must be unique and non-empty")
+        if transform.ndims.source != in_ndim:
+            raise ValueError(
+                f"Subtransform input dimensionality ({transform.ndims.source}) must match length of input_axes"
+            )
+        if transform.ndims.target != out_ndim:
+            raise ValueError(
+                f"Subtransform output dimensionality ({transform.ndims.target}) must match length of output_axes"
+            )
 
-        if in_ndim != out_ndim:
-            raise ValueError("Input and output axes must have the same length")
-
-        check_ndim(in_ndim, transform.ndim)
-
-        self.ndim = in_ndim
         self.transform = transform
 
 
@@ -51,7 +49,7 @@ class ByDimension(Transform[ArrayT]):
         subtransforms: list[SubTransform[ArrayT]],
         fill_identity: int | None = None,
         *,
-        spaces: SpaceTuple = (None, None),
+        spaces: Spaces = Spaces(None, None),
     ):
         """
         Parameters
@@ -64,8 +62,6 @@ class ByDimension(Transform[ArrayT]):
         spaces : tuple[SpaceRef, SpaceRef]
             Optional source and target spaces
         """
-        self.spaces = spaces
-
         if fill_identity is not None:
             to_fill_in = set(range(fill_identity))
             to_fill_out = set(range(fill_identity))
@@ -81,7 +77,9 @@ class ByDimension(Transform[ArrayT]):
                     except KeyError:
                         pass
             subtransforms.append(
-                SubTransform(Identity(), sorted(to_fill_in), sorted(to_fill_out))
+                SubTransform(
+                    Identity(len(to_fill_in)), sorted(to_fill_in), sorted(to_fill_out)
+                )
             )
 
         # check that input and output axes of sub transforms are disjoint
@@ -94,8 +92,8 @@ class ByDimension(Transform[ArrayT]):
         if sorted_out != list(range(len(sorted_out))):
             raise ValueError("N-length output axes must go from 0 to N-1")
 
+        super().__init__(NDims(len(sorted_in), len(sorted_out)), spaces=spaces)
         self.subtransforms = subtransforms
-        self.ndim = {len(sorted_in)}
 
     def apply(self, coords: ArrayT) -> ArrayT:
         """Apply transformation to subset of coordinates."""
@@ -123,7 +121,7 @@ class ByDimension(Transform[ArrayT]):
 
         return type(self)(
             subtransforms=inverted_transforms,
-            spaces=invert_spaces(self.spaces),
+            spaces=self.spaces.invert(),
         )
 
     def is_identity(self) -> bool:

--- a/src/transformnd/transforms/map_axis.py
+++ b/src/transformnd/transforms/map_axis.py
@@ -13,8 +13,6 @@ class MapAxis(Transform[ArrayT]):
 
     For example, x -> y and y -> x"""
 
-    # ndim: Optional[Set[int]] = set(2)
-
     def __init__(
         self,
         permutation: list[int],

--- a/src/transformnd/transforms/map_axis.py
+++ b/src/transformnd/transforms/map_axis.py
@@ -3,7 +3,8 @@ from array_api_compat import array_namespace
 import numpy as np
 
 from ..base import Transform
-from ..util import ArrayT, SpaceTuple, to_single_ndim
+from ..util import ArrayT
+from ..types import Spaces, NDims
 from ..transforms.affine import Affine
 
 
@@ -18,7 +19,7 @@ class MapAxis(Transform[ArrayT]):
         self,
         permutation: list[int],
         *,
-        spaces: SpaceTuple = (None, None),
+        spaces: Spaces = Spaces(None, None),
     ):
         """Base class for transformations.
 
@@ -35,18 +36,15 @@ class MapAxis(Transform[ArrayT]):
                 "N-D permutation must contain all dimensions [0, N) exactly once"
             )
         self.permutation = permutation
-        self.ndim = {len(permutation)}
-        self.spaces = spaces
+        super().__init__(NDims(len(permutation), len(permutation)), spaces=spaces)
 
     def is_identity(self) -> bool:
         return all(a == b for a, b in enumerate(self.permutation))
 
-    def to_affine(self, ndim: int | None = None) -> Affine[ArrayT] | None:
-        ndim = to_single_ndim(ndim, self.ndim)
-        m = np.eye(ndim + 1)
-        perm = self.permutation + [ndim]
-        m = m[perm, :]
-        return Affine(m, spaces=self.spaces)
+    def to_affine(self) -> Affine[ArrayT] | None:
+        m = np.eye(self.ndims.source)
+        m = m[self.permutation, :]
+        return Affine.from_linear_map(m, spaces=self.spaces)  # type: ignore
 
     def apply(self, coords: ArrayT) -> ArrayT:
         """Apply transformation to coordinates.
@@ -63,5 +61,5 @@ class MapAxis(Transform[ArrayT]):
     def invert(self) -> Self | None:
         return type(self)(
             list(np.argsort(self.permutation)),
-            spaces=(self.spaces[1], self.spaces[0]),
+            spaces=self.spaces.invert(),
         )

--- a/src/transformnd/transforms/moving_least_squares.py
+++ b/src/transformnd/transforms/moving_least_squares.py
@@ -9,8 +9,9 @@ import numpy as np
 from typing import Self
 from molesq.transform import Transformer as _Transformer
 
-from ..base import SpaceTuple, Transform
-from ..util import invert_spaces
+from ..base import Transform
+from ..types import NDims, Spaces
+from ..util import as_floats
 
 
 class MovingLeastSquares(Transform[np.ndarray]):
@@ -24,7 +25,7 @@ class MovingLeastSquares(Transform[np.ndarray]):
         source_control_points: np.ndarray,
         target_control_points: np.ndarray,
         *,
-        spaces: SpaceTuple = (None, None),
+        spaces: Spaces = Spaces(None, None),
     ):
         """Non-rigid transforms powered by molesq package.
 
@@ -38,12 +39,16 @@ class MovingLeastSquares(Transform[np.ndarray]):
         spaces : tuple[SpaceRef, SpaceRef]
             Optional source and target spaces
         """
-        super().__init__(spaces=spaces)
-        self._transformer = _Transformer(
-            np.asarray(source_control_points),
-            np.asarray(target_control_points),
+        s = as_floats(source_control_points)
+        t = as_floats(target_control_points)
+        self._transformer = _Transformer(s, t)
+        super().__init__(
+            NDims(
+                s.shape[1],
+                t.shape[1],
+            ),
+            spaces=spaces,
         )
-        self.ndim = {self._transformer.control_points.shape[1]}
 
     def apply(self, coords: np.ndarray) -> np.ndarray:
         coords = self._validate_coords(coords)
@@ -62,5 +67,5 @@ class MovingLeastSquares(Transform[np.ndarray]):
         return type(self)(
             self._transformer.deformed_control_points,
             self._transformer.control_points,
-            spaces=invert_spaces(self.spaces),
+            spaces=self.spaces.invert(),
         )

--- a/src/transformnd/transforms/reflection.py
+++ b/src/transformnd/transforms/reflection.py
@@ -5,7 +5,10 @@ from typing import Self
 import numpy as np
 from numpy.typing import ArrayLike
 
-from ..base import SpaceTuple, Transform
+from transformnd.transforms import Affine
+
+from ..base import Transform
+from ..types import NDims, Spaces
 from ..util import is_square
 
 
@@ -88,7 +91,7 @@ class Reflect(Transform[np.ndarray]):
         normals: ArrayLike,
         point: float | ArrayLike = 0.0,
         *,
-        spaces: SpaceTuple = (None, None),
+        spaces: Spaces = Spaces(None, None),
     ):
         """
         Parameters
@@ -107,7 +110,6 @@ class Reflect(Transform[np.ndarray]):
         ValueError
             Inconsistent dimensionality
         """
-        super().__init__(spaces=spaces)
         normals = np.asarray(normals)
         if normals.ndim == 1:
             normals = [normals]
@@ -123,6 +125,7 @@ class Reflect(Transform[np.ndarray]):
         self.ndim = {len(n1)}
         self.normals = [unitise(n) for n in normals]
         # todo: matmul is associative, so turn this into an affine in 2/3D?
+        super().__init__(NDims(len(n1), len(n1)), spaces=spaces)
 
     def apply(self, coords: np.ndarray) -> np.ndarray:
         coords = self._validate_coords(coords)
@@ -139,7 +142,7 @@ class Reflect(Transform[np.ndarray]):
         cls,
         points: ArrayLike,
         *,
-        spaces: SpaceTuple = (None, None),
+        spaces: Spaces = Spaces(None, None),
     ):
         """Infer a single plane of reflection from a minimal number of points on it.
 
@@ -163,7 +166,7 @@ class Reflect(Transform[np.ndarray]):
         axis: int | Sequence[int],
         origin: ArrayLike,
         *,
-        spaces: SpaceTuple = (None, None),
+        spaces: Spaces = Spaces(None, None),
     ):
         """Reflect around hyperplane(s) parallel with axes.
 
@@ -205,3 +208,8 @@ class Reflect(Transform[np.ndarray]):
 
     def invert(self) -> Self | None:
         return copy(self)
+
+    def to_affine(self) -> Affine[np.ndarray] | None:
+        # TODO: should be possible?
+        # rotate to align plane with origin and reflect it
+        return None

--- a/src/transformnd/transforms/simple.py
+++ b/src/transformnd/transforms/simple.py
@@ -11,7 +11,8 @@ from numpy.typing import ArrayLike
 from array_api_compat import array_namespace
 from array_api_compat import device as xp_device
 from ..base import Transform
-from ..util import ArrayT, chain_or, SpaceTuple, invert_spaces, to_single_ndim
+from ..types import NDims, Spaces
+from ..util import ArrayT, chain_or, as_floats
 from ..transforms.affine import Affine
 
 
@@ -20,9 +21,9 @@ class Identity(Transform[ArrayT]):
 
     def __init__(
         self,
-        ndim: int | set[int] | None = None,
+        ndim: int,
         *,
-        spaces: SpaceTuple = (None, None),
+        spaces: Spaces = Spaces(None, None),
     ):
         """
         Transform which does nothing.
@@ -37,24 +38,20 @@ class Identity(Transform[ArrayT]):
         ValueError
             [description]
         """
-        if isinstance(ndim, int):
-            ndim = {ndim}
         self.ndim = ndim
         src = chain_or(*spaces, default=None)
         tgt = chain_or(*spaces[::-1], default=None)
-        super().__init__(spaces=(src, tgt))
+        super().__init__(NDims(ndim, ndim), spaces=Spaces(src, tgt))
 
     def invert(self) -> Transform[ArrayT]:
-        return type(self)(self.ndim, spaces=invert_spaces(self.spaces))
+        return type(self)(self.ndim, spaces=self.spaces.invert())
 
-    def to_affine(self, ndim: int | None = None) -> Affine[ArrayT] | None:
-        ndim = to_single_ndim(ndim, self.ndim)
-        m = np.eye(ndim + 1)
+    def to_affine(self) -> Affine[ArrayT] | None:
+        m = np.eye(self.ndims.source + 1)
         return Affine(m, spaces=self.spaces)
 
     def apply(self, coords: ArrayT) -> ArrayT:
-        xp = array_namespace(coords)
-        return xp.asarray(coords)
+        return coords
 
 
 class Translate(Transform[ArrayT]):
@@ -64,13 +61,13 @@ class Translate(Transform[ArrayT]):
         self,
         translation: ArrayLike,
         *,
-        spaces: SpaceTuple = (None, None),
+        spaces: Spaces = Spaces(None, None),
     ):
         """Simple translation.
 
         Parameters
         ----------
-        translation : scalar or D-length array
+        translation : D-length array
             Translation to apply in all dimensions, or each dimension.
         spaces : tuple[SpaceRef, SpaceRef]
             Optional source and target spaces
@@ -80,21 +77,17 @@ class Translate(Transform[ArrayT]):
         ValueError
             If the translation is the wrong shape
         """
-        super().__init__(spaces=spaces)
-        self.translation = np.asarray(translation)
-        if self.translation.ndim > 1:
-            raise ValueError("Translation must be scalar or 1D")
+        self.translation = as_floats(translation)
+        if self.translation.ndim != 1:
+            raise ValueError(
+                f"Translation must be 1D, got shape {self.translation.shape}"
+            )
+        super().__init__(
+            NDims(len(self.translation), len(self.translation)), spaces=spaces
+        )
 
-        if self.translation.shape not in [(), (1,)]:
-            self.ndim = {self.translation.shape[0]}
-        # otherwise, can be broadcast to anything
-
-    def to_affine(self, ndim: int | None = None) -> Affine[ArrayT] | None:
-        ndim = to_single_ndim(ndim, self.ndim)
-
-        m = np.eye(ndim + 1)
-        m[:-1, -1] = self.translation
-        return Affine(m, spaces=self.spaces)
+    def to_affine(self) -> Affine[ArrayT] | None:
+        return Affine[ArrayT].translation(self.translation, spaces=self.spaces)
 
     def apply(self, coords: ArrayT) -> ArrayT:
         coords = self._validate_coords(coords)
@@ -103,7 +96,7 @@ class Translate(Transform[ArrayT]):
         return coords + xp.asarray(self.translation, device=d)
 
     def invert(self) -> Transform | None:
-        return type(self)(-self.translation, spaces=invert_spaces(self.spaces))
+        return type(self)(-self.translation, spaces=self.spaces.invert())
 
     def to_device(self, xp, device=None) -> Self:
         result = copy(self)
@@ -118,7 +111,7 @@ class Scale(Transform[ArrayT]):
         self,
         scale: ArrayLike,
         *,
-        spaces: SpaceTuple = (None, None),
+        spaces: Spaces = Spaces(None, None),
     ):
         """Simple scale transform.
 
@@ -136,25 +129,13 @@ class Scale(Transform[ArrayT]):
         ValueError
             If scale is the wrong shape.
         """
-        super().__init__(spaces=spaces)
-        self.scale = np.asarray(scale)
-        if self.scale.ndim > 1:
-            raise ValueError("Scale must be scalar or 1D")
+        self.scale = as_floats(scale)
+        if self.scale.ndim != 1:
+            raise ValueError(f"Scale must be 1D, got shape {self.scale.shape}")
+        super().__init__(NDims(len(self.scale), len(self.scale)), spaces=spaces)
 
-        if self.scale.shape not in [(), (1,)]:
-            self.ndim = {self.scale.shape[0]}
-        # otherwise, can be broadcast to anything
-
-    def to_affine(self, ndim: int | None = None) -> Affine[ArrayT] | None:
-        ndim = to_single_ndim(ndim, self.ndim)
-
-        if np.ndim(self.scale) == 0:
-            scale_vec = np.full(ndim, self.scale)
-        else:
-            scale_vec = self.scale
-        m = np.eye(ndim + 1)
-        m[:-1, :-1] = np.diag(scale_vec)
-        return Affine(m, spaces=self.spaces)
+    def to_affine(self) -> Affine[ArrayT] | None:
+        return Affine[ArrayT].scaling(self.scale, spaces=self.spaces)
 
     def apply(self, coords: ArrayT) -> ArrayT:
         coords = self._validate_coords(coords)
@@ -165,7 +146,7 @@ class Scale(Transform[ArrayT]):
     def invert(self) -> Self | None:
         return type(self)(
             1 / self.scale,
-            spaces=invert_spaces(self.spaces),
+            spaces=self.spaces.invert(),
         )
 
     def to_device(self, xp, device=None) -> Self:

--- a/src/transformnd/transforms/thinplate.py
+++ b/src/transformnd/transforms/thinplate.py
@@ -9,8 +9,9 @@ import logging
 import morphops as mops
 import numpy as np
 
-from ..base import SpaceTuple, Transform
-from ..util import check_ndim, invert_spaces
+from ..base import Transform
+from ..util import as_floats
+from ..types import Spaces, NDims
 
 logger = logging.getLogger(__name__)
 
@@ -21,14 +22,12 @@ class ThinPlateSplines(Transform[np.ndarray]):
     Deform based on matched pairs of control points.
     """
 
-    ndim = {2, 3}
-
     def __init__(
         self,
         source_control_points: np.ndarray,
         target_control_points: np.ndarray,
         *,
-        spaces: SpaceTuple = (None, None),
+        spaces: Spaces = Spaces(None, None),
     ):
         """Non-rigid control point based transforms in 2/3D.
 
@@ -49,9 +48,8 @@ class ThinPlateSplines(Transform[np.ndarray]):
         ValueError
             Invalid control points.
         """
-        super().__init__(spaces=spaces)
-        self.source_control_points = np.asarray(source_control_points)
-        self.target_control_points = np.asarray(target_control_points)
+        self.source_control_points = as_floats(source_control_points)
+        self.target_control_points = as_floats(target_control_points)
 
         if self.source_control_points.shape != self.target_control_points.shape:
             raise ValueError("Control point arrays must be the same shape")
@@ -60,19 +58,18 @@ class ThinPlateSplines(Transform[np.ndarray]):
             raise ValueError("Control points array must be 2D")
 
         ndim = self.source_control_points.shape[1]
-        check_ndim(ndim, self.ndim)
-        self.ndim = {ndim}
 
         self.W, self.A = mops.tps_coefs(
             self.source_control_points,
             self.target_control_points,
         )
+        super().__init__(NDims(ndim, ndim), spaces=spaces)
 
     def invert(self) -> Transform[np.ndarray] | None:
         return type(self)(
             self.target_control_points,
             self.source_control_points,
-            spaces=invert_spaces(self.spaces),
+            spaces=self.spaces.invert(),
         )
 
     def apply(self, coords: np.ndarray) -> np.ndarray:

--- a/src/transformnd/types.py
+++ b/src/transformnd/types.py
@@ -1,0 +1,46 @@
+from collections.abc import Sequence
+from typing import Callable, Hashable, NamedTuple, Self
+from typing_extensions import TypeVar
+import numpy as np
+
+from .constants import UNSPECIFIED_SPACE_NAME
+
+ArrayT = TypeVar("ArrayT", default=np.ndarray)
+
+type TransformSignature[ArrayT] = Callable[[ArrayT], ArrayT]
+"""Type annotation of a function which can be used as a transform."""
+
+type SpaceRef = Hashable
+"""Type annotation of identifiers which can be used to refer to spaces"""
+
+
+class SrcTgt[T](NamedTuple):
+    """2-tuple where the two members represent some feature of a source and target space."""
+
+    source: T
+    target: T
+
+    def invert(self) -> Self:
+        return type(self)(self.target, self.source)
+
+    @classmethod
+    def from_seq(cls, sequence: Sequence[T]) -> Self:
+        if len(sequence) != 2:
+            raise ValueError("Expected 2-length sequence")
+        return cls(sequence[0], sequence[1])
+
+    def __str__(self) -> str:
+        return f"{self.source}->{self.target}"
+
+
+class Spaces(SrcTgt[SpaceRef | None]):
+    """Source-target tuple for space identifiers."""
+
+    def __str__(self) -> str:
+        s = UNSPECIFIED_SPACE_NAME if self.source is None else self.source
+        t = UNSPECIFIED_SPACE_NAME if self.target is None else self.source
+        return f"{s}->{t}"
+
+
+class NDims(SrcTgt[int]):
+    """Source-target tuple for numbers of dimensions."""

--- a/src/transformnd/util.py
+++ b/src/transformnd/util.py
@@ -97,28 +97,6 @@ def same_or_none(*args: Any, default=NO_DEFAULT) -> Any:
     return prev
 
 
-def check_ndim(given_ndim: int, supported_ndim: set[int] | None) -> None:
-    """Raise a ValueError if dimensionality is unsupported.
-
-    Parameters
-    ----------
-    given_ndim : int
-        The dimensionality to check.
-    supported_ndim : Optional[Set[int]]
-        Which dimensions are supported.
-        If None, the check passes.
-
-    Raises
-    ------
-    ValueError
-        If supported dimensions are defined and given_ndim is not in them.
-    """
-    if supported_ndim is not None and given_ndim not in supported_ndim:
-        raise ValueError(
-            f"Transform supported for {format_dims(supported_ndim)}, not {given_ndim}"
-        )
-
-
 def format_dims(supported: set[int] | None) -> str:
     """Format supported dimensions for e.g. error messages.
 
@@ -151,33 +129,6 @@ def is_square(arr: ArrayT) -> bool:
     xp = array_namespace(arr)
     ndim, shape = xp.ndim(arr), xp.shape(arr)
     return ndim == 2 and shape[0] == shape[1]
-
-
-def dim_intersection(
-    dims1: set[int] | None, dims2: set[int] | None, error_on_empty: bool = False
-) -> set[int] | None:
-    """Find the intersection between two sets of constraints.
-
-    None means no constraints.
-    If `error_on_empty` is truthy and there is no intersection, raise an error.
-    """
-    if dims1 is None:
-        out = dims2
-    elif dims2 is None:
-        out = dims1
-    else:
-        out = dims1.intersection(dims2)
-    if error_on_empty and out is not None and len(out) == 0:
-        raise ValueError(f"incompatible dimensions: {dims1} ∩ {dims2}")
-    return out
-
-
-def are_coords(coords: ArrayT, ndim: set[int] | None = None):
-    xp = array_namespace(coords)
-    if xp.ndim(coords) != 2:
-        raise ValueError("Coords must be a 2D array")
-    check_ndim(xp.shape(coords)[1], ndim)
-    return coords
 
 
 def to_single_ndim(ndim: None | int = None, ndims: None | set[int] = None) -> int:

--- a/src/transformnd/util.py
+++ b/src/transformnd/util.py
@@ -1,26 +1,12 @@
 """Utilities used elsewhere in the package."""
 
-from collections import deque
-from collections.abc import Callable, Hashable, Iterable, Iterator
 from typing import Any
-
-# required for TypeVar(default=) argument
-from typing_extensions import TypeVar
-
-import numpy as np
 from array_api_compat import array_namespace
+from numpy.typing import ArrayLike
+import numpy as np
 
-UNSPECIFIED_SPACE_NAME = "???"
-
-ArrayT = TypeVar("ArrayT", default=np.ndarray)
-
-TransformSignature = Callable[[ArrayT], ArrayT]
-"""Type annotation of a function which can be used as a transform."""
-
-SpaceRef = Hashable
-"""Type annotation of things which can be used to refer to spaces"""
-
-SpaceTuple = tuple[SpaceRef | None, SpaceRef | None]
+from .types import SpaceRef, ArrayT
+from .constants import UNSPECIFIED_SPACE_NAME
 
 
 def none_eq(a: Any | None, b: Any | None) -> bool:
@@ -111,35 +97,6 @@ def same_or_none(*args: Any, default=NO_DEFAULT) -> Any:
     return prev
 
 
-def window[T](iterable: Iterable[T], length: int) -> Iterator[tuple[T, ...]]:
-    """Sliding window over iterable.
-
-    e.g. `(it[0], it[1]), (it[1], it[2]), (it[2], it[3]), ...`
-
-    Parameters
-    ----------
-    iterable : Iterable
-    length : int
-        Length of windows to return.
-
-    Yields
-    -------
-    Tuple[Any, ...]
-    """
-    it = iter(iterable)
-    q: deque[Any] = deque(maxlen=length)
-    for _ in range(length):
-        try:
-            item = next(it)
-        except StopIteration:
-            return
-        q.append(item)
-    yield tuple(q)
-    for item in it:
-        q.append(item)
-        yield tuple(q)
-
-
 def check_ndim(given_ndim: int, supported_ndim: set[int] | None) -> None:
     """Raise a ValueError if dimensionality is unsupported.
 
@@ -215,11 +172,6 @@ def dim_intersection(
     return out
 
 
-def invert_spaces(spaces: SpaceTuple) -> SpaceTuple:
-    """Invert the given (source, target) space tuple."""
-    return (spaces[1], spaces[0])
-
-
 def are_coords(coords: ArrayT, ndim: set[int] | None = None):
     xp = array_namespace(coords)
     if xp.ndim(coords) != 2:
@@ -249,3 +201,11 @@ def to_single_ndim(ndim: None | int = None, ndims: None | set[int] = None) -> in
         return ndim
 
     raise ValueError(f"dimensionality conflict: {ndim} not in {ndims}")
+
+
+def as_floats(arr: ArrayLike):
+    """Get array-like as a numpy array, casting to float if integral."""
+    arr = np.asarray(arr)
+    if not np.issubdtype(arr.dtype, np.floating):
+        arr = arr.astype(np.float64)
+    return arr

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,5 +1,5 @@
 from transformnd.base import Transform
-from transformnd.util import SpaceTuple, to_single_ndim
+from transformnd.types import Spaces, NDims
 from transformnd.transforms.affine import Affine
 from copy import copy
 import numpy as np
@@ -10,14 +10,13 @@ class NullTransform(Transform):
 
     def __init__(
         self,
-        ndim: set[int] | None = None,
+        ndim: int,
         invertible: bool = False,
         affineable: bool = False,
         *,
-        spaces: SpaceTuple = (None, None),
+        spaces: Spaces = Spaces(None, None),
     ):
-        super().__init__(spaces=spaces)
-        self.ndim = ndim
+        super().__init__(NDims(ndim, ndim), spaces=spaces)
         self.invertible = invertible
         self.affineable = affineable
 
@@ -26,10 +25,9 @@ class NullTransform(Transform):
             return copy(self)
         return None
 
-    def to_affine(self, ndim: int | None = None) -> Affine | None:
-        ndim = to_single_ndim(ndim, self.ndim)
+    def to_affine(self) -> Affine | None:
         if self.affineable:
-            return Affine.identity(ndim, spaces=self.spaces)
+            return Affine.identity(self.ndims.source, spaces=self.spaces)
         return None
 
     def apply(self, coords: np.ndarray) -> np.ndarray:

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -4,9 +4,10 @@ import numpy as np
 import pytest
 
 from transformnd.base import TransformSequence, TransformWrapper
+from transformnd.types import Spaces
 from transformnd.transforms.simple import Translate, Scale
 from transformnd.transforms.affine import Affine
-from transformnd.util import window
+from itertools import pairwise
 
 from .common import NullTransform
 
@@ -16,7 +17,7 @@ def noop(arg):
 
 
 def test_transform(coords5x3):
-    t = TransformWrapper(noop, spaces=(1, 2))
+    t = TransformWrapper(noop, 3, 3, spaces=Spaces(1, 2))
 
     assert np.allclose(t.apply(coords5x3), coords5x3)
 
@@ -24,27 +25,27 @@ def test_transform(coords5x3):
 def test_sequence(coords5x3):
     ts = []
     last = 3
-    for a, b in window(range(last + 1), 2):
-        ts.append(TransformWrapper(noop, spaces=(a, b)))
+    for a, b in pairwise(range(last + 1)):
+        ts.append(TransformWrapper(noop, 3, 3, spaces=Spaces(a, b)))
 
     t = TransformSequence(ts)
     assert np.allclose(t.apply(coords5x3), coords5x3)
-    assert t.source_space == 0
-    assert t.target_space == last
+    assert t.spaces.source == 0
+    assert t.spaces.target == last
 
 
 def test_sequence_errors():
     with pytest.raises(ValueError):
         TransformSequence(
             [
-                TransformWrapper(noop, spaces=(1, 2)),
-                TransformWrapper(noop, spaces=(3, 4)),
+                TransformWrapper(noop, 3, 3, spaces=Spaces(1, 2)),
+                TransformWrapper(noop, 3, 3, spaces=Spaces(3, 4)),
             ]
         )
 
 
 def test_sequence_does_not_split():
-    t = TransformWrapper(noop)
+    t = TransformWrapper(noop, 3, 3)
     seq1 = t | copy(t)
     seq2 = TransformSequence([copy(t), seq1, copy(t)])
     assert len(seq2) == 3
@@ -54,15 +55,15 @@ def test_sequence_does_not_split():
 def test_sequence_infers():
     t = TransformSequence(
         [
-            TransformWrapper(noop, spaces=(0, None)),
-            TransformWrapper(noop, spaces=(1, 2)),
+            TransformWrapper(noop, 3, 3, spaces=Spaces(0, None)),
+            TransformWrapper(noop, 3, 3, spaces=Spaces(1, 2)),
         ]
     )
-    assert t[0].target_space == 1
+    assert t[0].spaces.target == 1
 
 
 def test_add():
-    t = [TransformWrapper(noop) for _ in range(5)]
+    t = [TransformWrapper(noop, 3, 3) for _ in range(5)]
     t12 = t[1] | t[2]
     assert isinstance(t12, TransformSequence)
     assert len(t12) == 2
@@ -87,8 +88,8 @@ def test_maths():
 def test_simplify_affine1(rng):
     s1 = Scale(np.array([5, 5, 5], float))
     s2 = Translate(np.array([2, 3, 4], float))
-    s3 = NullTransform()
-    s4 = Scale(6)
+    s3 = NullTransform(3)
+    s4 = Scale([6, 6, 6])
     coords = rng.random((10, 3))
     sequence = TransformSequence([s1, s2, s3, s4])
     expected = sequence.apply(coords)
@@ -104,13 +105,13 @@ def test_simplify_affine1(rng):
 def test_simplify_affine2(rng):
     coords = rng.random((10, 3))
     dim = 3
-    s1 = NullTransform()
+    s1 = NullTransform(dim)
     s2 = Scale(np.array([5, 5, 5], float))
     s3 = Translate(np.array([2, 3, 4], float))
     s4 = Scale(6)
     s2_affine = s2.to_affine()
     s3_affine = s3.to_affine()
-    s4_affine = s4.to_affine(dim)
+    s4_affine = s4.to_affine()
     assert s2_affine is not None
     assert s3_affine is not None
     assert s4_affine is not None

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -78,7 +78,7 @@ def test_add():
 
 
 def test_maths():
-    t1 = Translate[np.ndarray](1)
+    t1 = Translate[np.ndarray]([1] * 3)
     coords = np.zeros((5, 3))
 
     assert np.allclose((t1 | ~t1).apply(coords), coords)
@@ -108,7 +108,7 @@ def test_simplify_affine2(rng):
     s1 = NullTransform(dim)
     s2 = Scale(np.array([5, 5, 5], float))
     s3 = Translate(np.array([2, 3, 4], float))
-    s4 = Scale(6)
+    s4 = Scale([6] * 3)
     s2_affine = s2.to_affine()
     s3_affine = s3.to_affine()
     s4_affine = s4.to_affine()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,6 +1,6 @@
 import pytest
 
-from transformnd.util import chain_or, none_eq, same_or_none, window
+from transformnd.util import chain_or, none_eq, same_or_none
 
 
 def test_same_or_none():
@@ -26,14 +26,3 @@ def test_chain_or():
     with pytest.raises(ValueError):
         chain_or(None)
     assert chain_or(None, default=1) == 1
-
-
-def test_window():
-    test = list(window(range(5), 2))
-    ref = [
-        (0, 1),
-        (1, 2),
-        (2, 3),
-        (3, 4),
-    ]
-    assert test == ref

--- a/tests/transforms/test_affine.py
+++ b/tests/transforms/test_affine.py
@@ -16,11 +16,11 @@ def test_identity():
 
 @pytest.mark.parametrize(["ndim"], [[d] for d in range(1, 6)])
 def test_translation(ndim, rng):
-    t = 1
+    t = [1]
 
     coords = rng.random((5, ndim)) - 0.5
     t_arr = [t] * ndim
-    trans = Affine[np.ndarray].translation(t, ndim)
+    trans = Affine[np.ndarray].translation(t)
     trans_arr = Affine[np.ndarray].translation(t_arr)
     assert np.allclose(trans.apply(coords), coords + t)
     assert np.allclose(trans_arr.apply(coords), coords + t)
@@ -29,15 +29,15 @@ def test_translation(ndim, rng):
 
 @pytest.mark.parametrize(["ndim"], [[d] for d in range(2, 6)])
 def test_scaling(ndim, rng):
-    s = 2
+    s = [2] * ndim
+    s_arr = [s] * ndim
 
     coords = rng.random((5, ndim)) - 0.5
-    trans = Affine[np.ndarray].scaling(s, ndim)
+    trans = Affine[np.ndarray].scaling(s_arr)
     assert np.allclose(trans.apply(coords), coords * s)
     assert np.allclose((~trans).apply(coords), coords / s)
 
-    t_arr = [s] * ndim
-    trans_arr = Affine[np.ndarray].scaling(t_arr)
+    trans_arr = Affine[np.ndarray].scaling(s_arr)
     assert np.allclose(trans_arr.apply(coords), coords * s)
 
 

--- a/tests/transforms/test_affine.py
+++ b/tests/transforms/test_affine.py
@@ -16,20 +16,18 @@ def test_identity():
 
 @pytest.mark.parametrize(["ndim"], [[d] for d in range(1, 6)])
 def test_translation(ndim, rng):
-    t = [1]
+    t = 1
 
     coords = rng.random((5, ndim)) - 0.5
     t_arr = [t] * ndim
-    trans = Affine[np.ndarray].translation(t)
     trans_arr = Affine[np.ndarray].translation(t_arr)
-    assert np.allclose(trans.apply(coords), coords + t)
     assert np.allclose(trans_arr.apply(coords), coords + t)
-    assert np.allclose((~trans).apply(coords), coords - t)
+    assert np.allclose((~trans_arr).apply(coords), coords - t)
 
 
 @pytest.mark.parametrize(["ndim"], [[d] for d in range(2, 6)])
 def test_scaling(ndim, rng):
-    s = [2] * ndim
+    s = 2
     s_arr = [s] * ndim
 
     coords = rng.random((5, ndim)) - 0.5

--- a/tests/transforms/test_bijection.py
+++ b/tests/transforms/test_bijection.py
@@ -54,15 +54,10 @@ def test_bijection_roundtrip(coords5x3):
 
 
 def test_bijection_dim_mismatch():
-    forward = Scale[np.ndarray](2)
-    inverse = Scale[np.ndarray](0.5)
-    bij = Bijection(forward, inverse)
-    assert bij.ndim is None  # both support all dimensions
-
     forward_2d = MapAxis(permutation=[1, 0])
     inverse_2d = MapAxis(permutation=[1, 0])
     bij_2d = Bijection(forward_2d, inverse_2d)
-    assert bij_2d.ndim == {2}
+    assert bij_2d.ndims.source == 2
 
     forward_3d = MapAxis([2, 1, 0])
 

--- a/tests/transforms/test_bijection.py
+++ b/tests/transforms/test_bijection.py
@@ -2,12 +2,14 @@ import numpy as np
 import pytest
 
 from transformnd.transforms import Bijection, Scale, MapAxis
+from transformnd.util import as_floats
 
 
 def test_bijection_apply_scale():
-    scale = 1.5
+    ndim = 3
+    scale = as_floats([1.5] * ndim)
     rng = np.random.default_rng(1991)
-    coords5x3 = rng.random((5, 3))
+    coords5x3 = rng.random((5, ndim))
     forward = Scale(scale)
     inverse = Scale(1 / scale)
     bij = Bijection(forward, inverse)
@@ -27,9 +29,10 @@ def test_bijection_apply_map_axis():
 
 def test_bijection_invert_scale():
     rng = np.random.default_rng(1991)
-    coords5x3 = rng.random((5, 3))
-    forward = Scale(2)
-    inverse = Scale(0.5)
+    ndim = 3
+    coords5x3 = rng.random((5, ndim))
+    forward = Scale([2] * ndim)
+    inverse = Scale([0.5] * ndim)
     bij = Bijection(forward, inverse)
     bij_inv = ~bij
     assert np.allclose(bij_inv.apply(coords5x3), coords5x3 * 0.5)
@@ -47,8 +50,9 @@ def test_bijection_invert_map_axis():
 
 
 def test_bijection_roundtrip(coords5x3):
-    forward = Scale[np.ndarray](3)
-    inverse = Scale[np.ndarray](1 / 3)
+    ndim = 3
+    forward = Scale[np.ndarray]([3] * ndim)
+    inverse = Scale[np.ndarray]([1 / 3] * ndim)
     bij = Bijection(forward, inverse)
     assert np.allclose((~bij).apply(bij.apply(coords5x3)), coords5x3)
 

--- a/tests/transforms/test_by_dimension.py
+++ b/tests/transforms/test_by_dimension.py
@@ -7,7 +7,7 @@ from transformnd.base import TransformSequence
 
 
 def test_2d_scale():
-    factor = 1.5
+    factor = [1.5]
     coords = np.array([[1, 2], [3, 4]], dtype=float)
     scale = Scale[np.ndarray](factor)
     subseq = SubTransform(input_axes=[0], output_axes=[0], transform=scale)
@@ -29,7 +29,7 @@ def test_3d_map_axis_and_scale():
     )
 
     # Scale: apply scale to column 2
-    scale = Scale[np.ndarray](s)
+    scale = Scale[np.ndarray]([s])
     scale_subseq = SubTransform[np.ndarray](
         input_axes=[2], output_axes=[2], transform=scale
     )
@@ -65,14 +65,14 @@ def test_3d_transform_sequence():
 
     # MapAxis: swap columns 0 and 1, keep column 2
     map_axis = MapAxis[np.ndarray](permutation=[1, 0])
-    scale_seq = Scale[np.ndarray](s + 2)
+    scale_seq = Scale[np.ndarray]([s + 2] * 2)
     transform_sequence = TransformSequence[np.ndarray]([map_axis, scale_seq])
     map_axis_subseq = SubTransform(
         input_axes=[0, 1], output_axes=[0, 1], transform=transform_sequence
     )
 
     # Scale: apply scale to column 2
-    scale = Scale[np.ndarray](s)
+    scale = Scale[np.ndarray]([s])
     scale_subseq = SubTransform(input_axes=[2], output_axes=[2], transform=scale)
 
     # Apply both transformations
@@ -93,7 +93,7 @@ def test_3d_transform_sequence():
 
 def test_non_unique_axes():
     """Test that non-unique axes raise an error."""
-    scale = Scale[np.ndarray](2)
+    scale = Scale[np.ndarray]([2])
     # non-unique input axes
     with pytest.raises(ValueError):
         SubTransform(input_axes=[0, 0], output_axes=[0, 1], transform=scale)
@@ -111,10 +111,10 @@ def test_cross_axes_transform():
     coords = np.array([[1, 2], [3, 4]], dtype=float)
     coords_transformed = np.array([[2 * s_2, 1 * s_1], [4 * s_2, 3 * s_1]])
     t_1 = SubTransform(
-        input_axes=[0], output_axes=[1], transform=Scale[np.ndarray](s_1)
+        input_axes=[0], output_axes=[1], transform=Scale[np.ndarray]([s_1])
     )
     t_2 = SubTransform(
-        input_axes=[1], output_axes=[0], transform=Scale[np.ndarray](s_2)
+        input_axes=[1], output_axes=[0], transform=Scale[np.ndarray]([s_2])
     )
     by_dim = ByDimension(subtransforms=[t_1, t_2])
     coords_byDim = by_dim.apply(coords.copy())

--- a/tests/transforms/test_simple.py
+++ b/tests/transforms/test_simple.py
@@ -1,13 +1,12 @@
 import numpy as np
 
 from transformnd.transforms.simple import Identity, Scale, Translate
+from transformnd.types import Spaces
 
 
 def test_identity_spaces():
-    t = Identity[np.ndarray](spaces=(1, 1))
-    assert t.target_space == 1
-
-    Identity(spaces=(1, 2))
+    t = Identity[np.ndarray](1, spaces=Spaces(1, 1))
+    assert t.spaces.target == 1
 
 
 def test_translate_nd(coords5x3):

--- a/tests/transforms/test_simple.py
+++ b/tests/transforms/test_simple.py
@@ -9,11 +9,6 @@ def test_identity_spaces():
     assert t.spaces.target == 1
 
 
-def test_translate_nd(coords5x3):
-    t = Translate[np.ndarray](1)
-    assert np.allclose(t.apply(coords5x3), coords5x3 + 1)
-
-
 def test_translate_3d(coords5x3):
     trans = [1, 2, 3]
     t = Translate[np.ndarray](np.array(trans))
@@ -21,13 +16,8 @@ def test_translate_3d(coords5x3):
 
 
 def test_translate_neg(coords5x3):
-    t_neg = ~Translate(1)
+    t_neg = ~Translate([1] * 3)
     assert np.allclose(t_neg.apply(coords5x3), coords5x3 - 1)
-
-
-def test_scale_nd(coords5x3):
-    t = Scale[np.ndarray](2)
-    assert np.allclose(t.apply(coords5x3), coords5x3 * 2)
 
 
 def test_scale_3d(coords5x3):
@@ -37,5 +27,5 @@ def test_scale_3d(coords5x3):
 
 
 def test_scale_neg(coords5x3):
-    t_neg = ~Scale(2)
+    t_neg = ~Scale([2] * 3)
     assert np.allclose(t_neg.apply(coords5x3), coords5x3 / 2)


### PR DESCRIPTION
All transforms must now have an explicit input and output dimensionality; the dimension-agnostic forms of the identity, translation, and scaling transforms have been removed.

This actually simplified a lot of code.