### PR TITLE
fix: correct ordering of spaces in chaining affines

### DIFF
--- a/src/transformnd/transforms/affine.py
+++ b/src/transformnd/transforms/affine.py
@@ -172,7 +172,7 @@ class Affine(Transform[ArrayT]):
             raise ValueError("Affine transforms do not share a space")
         return Affine(
             self.matrix @ rhs.matrix,
-            spaces=Spaces(self.spaces.source, rhs.spaces.target),
+            spaces=Spaces(rhs.spaces.source, self.spaces.target),
         )
 
     def to_device(self, xp, device=None) -> "Affine[ArrayT]":

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,0 +1,32 @@
+from transformnd.base import TransformSequence
+from transformnd.graph import TransformGraph
+from transformnd.types import Spaces
+from transformnd.transforms.simple import Translate, Scale
+from transformnd.transforms.affine import Affine
+
+import numpy as np
+
+def test_graph_traversal():
+    t1 = Translate([1, 2], spaces=Spaces("A", "B"))
+    t2 = Scale([2, 3], spaces=Spaces("B", "C"))
+    t3 = Affine(np.eye(3), spaces=Spaces("C", "D"))
+
+    graph = TransformGraph()
+    graph.add_transforms([t1])
+    graph.add_transforms([t2])
+    graph.add_transforms([t3])
+
+    seq = graph.get_sequence("A", "D")
+    assert isinstance(seq, TransformSequence)
+    assert len(seq) == 1
+
+    simplified_seq = seq.simplify()
+    assert simplified_seq.spaces.source == "A"
+    assert simplified_seq.spaces.target == "D"
+
+    expected_affine = np.array([[2, 0, 2], [0, 3, 6], [0, 0, 1]])
+    assert np.array_equal(simplified_seq.to_affine().matrix, expected_affine)
+
+if __name__ == "__main__":
+    test_graph_traversal()
+    print("All tests passed!")

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -4,17 +4,17 @@ from transformnd.types import Spaces
 from transformnd.transforms.simple import Translate, Scale
 from transformnd.transforms.affine import Affine
 
+import pytest
+
 import numpy as np
+
 
 def test_graph_traversal():
     t1 = Translate([1, 2], spaces=Spaces("A", "B"))
     t2 = Scale([2, 3], spaces=Spaces("B", "C"))
     t3 = Affine(np.eye(3), spaces=Spaces("C", "D"))
 
-    graph = TransformGraph()
-    graph.add_transforms([t1])
-    graph.add_transforms([t2])
-    graph.add_transforms([t3])
+    graph: TransformGraph = TransformGraph([t1, t2, t3])
 
     seq = graph.get_sequence("A", "D")
     assert isinstance(seq, TransformSequence)
@@ -25,7 +25,10 @@ def test_graph_traversal():
     assert simplified_seq.spaces.target == "D"
 
     expected_affine = np.array([[2, 0, 2], [0, 3, 6], [0, 0, 1]])
-    assert np.array_equal(simplified_seq.to_affine().matrix, expected_affine)
+    got_affine = simplified_seq.to_affine()
+    assert got_affine is not None
+    assert got_affine.matrix == pytest.approx(expected_affine)
+
 
 if __name__ == "__main__":
     test_graph_traversal()


### PR DESCRIPTION
Fixes #51 

@clbarnes I think this fixes how source/target spaces are added to the `TransformSequence` during simplification. Essentially, with chaining two or more transforms, I ended up with an `Affine` where `aff.spaces` was something like (`"system1", "system1")`. This reverses the ordering and fixes it. Would be good to add a test for this, too.