### PR TITLE
feat: use setuptools_scm for dynamic versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ __pycache__/
 # C extensions
 *.so
 
+# setuptools
+*_version.py
+
 # Distribution / packaging
 .Python
 build/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "transformnd"
-version = "0.7.2"
+dynamic = ["version"]
 description = "ND coordinate transformations"
 readme = "README.md"
 authors = [{ name = "Chris Barnes", email = "chris.barnes@gerbi-gmb.de" }]
@@ -92,8 +92,12 @@ bench = [
 ]
 
 [build-system]
-requires = ["uv_build>=0.11.0,<0.12.0"]
-build-backend = "uv_build"
+requires = [
+    "uv_build>=0.11.0,<0.12.0",
+    "setuptools>=77.0.3",
+    "setuptools-scm>=8.0",
+    ]
+build-backend = "setuptools.build_meta"
 
 [tool.mypy]
 ignore_missing_imports = true
@@ -112,3 +116,6 @@ lint.external = [
     "DOC",  # pydoclint
     "D",  # pydocstyle
 ]
+
+[tool.setuptools_scm]
+version_file = "src/transformnd/_version.py"


### PR DESCRIPTION
@clbarnes bumping the version is probably a bit annoying over time, plus it's nice if a package declares its own version under, say `transformn.__version__`. Setuptools_scm does this automatically on release. It grabs the git tag when you publish and builds a `_version.py` for you.

The uv build currently [doesn't support dynamic versioning yet](https://github.com/astral-sh/uv/issues/8714).

And I'm *suspecting* that the failing tests over at https://github.com/ome/ome-zarr-py/pull/583 may be related to this issue.