### PR TITLE
Tighten return types of always-succeeding `to_affine()`

### DIFF
--- a/src/transformnd/transforms/affine.py
+++ b/src/transformnd/transforms/affine.py
@@ -78,7 +78,7 @@ class Affine(Transform[ArrayT]):
         if np.allclose(np.zeros_like(self._translation), self._translation):
             self._translation = None
 
-    def to_affine(self) -> Self | None:
+    def to_affine(self) -> Self:
         return self
 
     def cast_matrix(self, namespace, device) -> ArrayT:

--- a/src/transformnd/transforms/map_axis.py
+++ b/src/transformnd/transforms/map_axis.py
@@ -44,7 +44,7 @@ class MapAxis(Transform[ArrayT]):
     def is_identity(self) -> bool:
         return all(a == b for a, b in enumerate(self.permutation))
 
-    def to_affine(self) -> Affine[ArrayT] | None:
+    def to_affine(self) -> Affine[ArrayT]:
         m = np.eye(self.ndims.source)
         m = m[self.permutation, :]
         return Affine.from_linear_map(m, spaces=self.spaces)  # type: ignore

--- a/src/transformnd/transforms/project_axis.py
+++ b/src/transformnd/transforms/project_axis.py
@@ -92,7 +92,7 @@ class ProjectAxis(Transform):
     def is_identity(self) -> bool:
         return not self.created and not self.dropped
 
-    def to_affine(self) -> Affine | None:
+    def to_affine(self) -> Affine:
         m = np.eye(self.ndims.source)
         out_m = self.apply(m)
         return Affine.from_linear_map(out_m.T)

--- a/src/transformnd/transforms/simple.py
+++ b/src/transformnd/transforms/simple.py
@@ -42,7 +42,7 @@ class Identity(Transform[ArrayT]):
     def invert(self) -> Transform[ArrayT]:
         return type(self)(self.ndims.source, spaces=self.spaces.invert())
 
-    def to_affine(self) -> Affine[ArrayT] | None:
+    def to_affine(self) -> Affine[ArrayT]:
         return Affine[ArrayT].identity(self.ndims.source, spaces=self.spaces)
 
     def apply(self, coords: ArrayT) -> ArrayT:
@@ -81,7 +81,7 @@ class Translate(Transform[ArrayT]):
             NDims(len(self.translation), len(self.translation)), spaces=spaces
         )
 
-    def to_affine(self) -> Affine[ArrayT] | None:
+    def to_affine(self) -> Affine[ArrayT]:
         return Affine[ArrayT].translation(self.translation, spaces=self.spaces)
 
     def apply(self, coords: ArrayT) -> ArrayT:
@@ -129,7 +129,7 @@ class Scale(Transform[ArrayT]):
             raise ValueError(f"Scale must be 1D, got shape {self.scale.shape}")
         super().__init__(NDims(len(self.scale), len(self.scale)), spaces=spaces)
 
-    def to_affine(self) -> Affine[ArrayT] | None:
+    def to_affine(self) -> Affine[ArrayT]:
         return Affine[ArrayT].scaling(self.scale, spaces=self.spaces)
 
     def apply(self, coords: ArrayT) -> ArrayT:


### PR DESCRIPTION
Some transformations always succeed when calling `.to_affine()`, but their method signature still returns `Affine | None`. This patch tightens their types to simply return `Affine` when we know they always succeed. This is still compatible with the parent signature (i.e. `Affine` is a subtype of `Affine | None`), but is convenient for code that is dealing with concrete children of `Transform`, since they don't have to `assert` that `to_affine() is not None`:

```python
# before:
def use_scale(scale: Scale):
    scale_affine = scale.to_affine()
    assert scale_affine is not None
    use_affine(scale_affine)

# after
def use_scale2(scale: Scale):
    scale_affine = scale.to_affine()
    use_affine(scale_affine)
```